### PR TITLE
add priority fees addon example

### DIFF
--- a/solana/priority-fees-addon/app.ts
+++ b/solana/priority-fees-addon/app.ts
@@ -1,0 +1,80 @@
+/**
+ * 
+ *  Sample Usage of QuickNode's Solana Priority Fees Add-on
+ *  
+ *  Description:
+ *  This script demonstrates how to use QuickNode's Solana Priority Fees Add-on to estimate the cost of a transaction
+ *  and create a dynamic priority fee instruction for a Solana transaction based on your own business logic.
+ * 
+ *  Resources:
+ *  Add-on Page: https://marketplace.quicknode.com/add-on/solana-priority-fee
+ *  Guide: https://www.quicknode.com/guides/solana-development/transactions/how-to-use-priority-fees
+ *  Documentation: https://quicknode.com/docs/solana/qn_estimatePriorityFees
+ *  
+ */
+
+import { Transaction, ComputeBudgetProgram } from "@solana/web3.js";
+import { RequestPayload, ResponseData, EstimatePriorityFeesParams } from "./types";
+
+async function fetchEstimatePriorityFees({
+    last_n_blocks,
+    account,
+    endpoint
+}: EstimatePriorityFeesParams): Promise<ResponseData> {
+    const params: any = {};
+    if (last_n_blocks !== undefined) {
+        params.last_n_blocks = last_n_blocks;
+    }
+    if (account !== undefined) {
+        params.account = account;
+    }
+
+    const payload: RequestPayload = {
+        method: 'qn_estimatePriorityFees',
+        params,
+        id: 1,
+        jsonrpc: '2.0',
+    };
+
+    const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data: ResponseData = await response.json();
+    return data;
+}
+
+
+/**
+ * Example of creating a dynamic priority fee instruction for a Solana transaction
+ */
+
+const params: EstimatePriorityFeesParams = {
+    last_n_blocks: 100,
+    account: 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4',
+    endpoint: 'https://YOUR_QUICKNODE_ADDON_URL/'
+};
+
+
+async function createDynamicPriorityFeeInstruction() {
+    const { result } = await fetchEstimatePriorityFees(params);
+    console.table(result);
+    const priorityFee = result.per_compute_unit.high; // 👈 Replace depending on your transaction requirements (e.g., low, medium, high, or specific percentile)
+    const priorityFeeInstruction = ComputeBudgetProgram.setComputeUnitPrice({ microLamports: priorityFee });
+    return priorityFeeInstruction;
+}
+
+async function main() {
+    const priorityFeeInstruction = await createDynamicPriorityFeeInstruction()
+    const transaction = new Transaction().add(priorityFeeInstruction);
+    // Construct and handle the rest of the transaction
+    // ...
+}

--- a/solana/priority-fees-addon/types.ts
+++ b/solana/priority-fees-addon/types.ts
@@ -1,0 +1,43 @@
+
+interface RequestPayload {
+    method: string;
+    params: {
+        last_n_blocks: number;
+        account: string;
+    };
+    id: number;
+    jsonrpc: string;
+}
+
+interface FeeEstimates {
+    extreme: number;
+    high: number;
+    low: number;
+    medium: number;
+    percentiles: {
+        [key: string]: number;
+    };
+}
+
+interface ResponseData {
+    jsonrpc: string;
+    result: {
+        context: {
+            slot: number;
+        };
+        per_compute_unit: FeeEstimates;
+        per_transaction: FeeEstimates;
+    };
+    id: number;
+}
+
+interface EstimatePriorityFeesParams {
+    // (Optional) The number of blocks to consider for the fee estimate
+    last_n_blocks?: number;
+    // (Optional) The program account to use for fetching the local estimate (e.g., Jupiter: JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4)
+    account?: string;
+    // Your Add-on Endpoint (found in your QuickNode Dashboard - https://dashboard.quicknode.com/endpoints)
+    endpoint: string;
+}
+
+export type { RequestPayload, FeeEstimates, ResponseData, EstimatePriorityFeesParams };


### PR DESCRIPTION
Supporting example for Priority Fee add-on

[Priority Fee Guide](https://www.quicknode.com/guides/solana-development/transactions/how-to-use-priority-fees#calculating-priority-fee-rates-for-production-applications) 
[Priority Fee Add-on Docs](https://quicknode.com/docs/solana/qn_estimatePriorityFees) 