### PR TITLE
Use public jupiter API

### DIFF
--- a/solana/jupiter-bot/index.ts
+++ b/solana/jupiter-bot/index.ts
@@ -8,7 +8,7 @@ dotenv.config({
 
 const defaultConfig = {
     solanaEndpoint: clusterApiUrl("mainnet-beta"),
-    jupiter: "https://quote-api.jup.ag/v6",
+    jupiter: "https://public.jupiterapi.com",
 };
 
 async function main() {


### PR DESCRIPTION
Updates Jupiter URL to use [jupiterapi.com](https://jupiterapi.com)