### PR TITLE
[CON-342] Fix create rpc api in solana web3js2 examples

### DIFF
--- a/solana/web3.js-2.0/jito-bundles/lilJit.ts
+++ b/solana/web3.js-2.0/jito-bundles/lilJit.ts
@@ -2,7 +2,7 @@ import {
     Rpc,
     createDefaultRpcTransport,
     createRpc,
-    createRpcApi,
+    createJsonRpcApi, // note: in older versions of this library, this function was called: createRpcApi
     Address,
     mainnet,
     Base58EncodedBytes,
@@ -83,7 +83,7 @@ type LilJitAddon = {
 }
 
 function createJitoBundlesRpc({ endpoint }: { endpoint: string }): Rpc<LilJitAddon> {
-    const api = createRpcApi<LilJitAddon>({
+    const api = createJsonRpcApi<LilJitAddon>({
         // parametersTransformer: (params: any[]) => params[0],
         responseTransformer: (response: any) => response.result,
     });

--- a/solana/web3.js-2.0/optimized-tx/src/QuickNodeSolana.ts
+++ b/solana/web3.js-2.0/optimized-tx/src/QuickNodeSolana.ts
@@ -1,7 +1,8 @@
 import {
     Rpc,
     createRpc,
-    createRpcApi,
+    createJsonRpcApi, // note: in older versions of this library, this function was called: createRpcApi
+    RpcRequest,
     pipe,
     createTransactionMessage,
     setTransactionMessageLifetimeUsingBlockhash,
@@ -56,8 +57,8 @@ export class QuickNodeSolana {
     }
 
     private createPriorityFeeApi(endpoint: string): Rpc<PriorityFeeApi> {
-        const api = createRpcApi<PriorityFeeApi>({
-            parametersTransformer: (params: any[]) => params[0],
+        const api = createJsonRpcApi<PriorityFeeApi>({
+            requestTransformer: (request: RpcRequest<any>) => request.params[0],
             responseTransformer: (response: any) => response.result,
         });
         const transport = createQuickNodeTransport(endpoint);

--- a/solana/web3.js-2.0/quicknode-addons/guide1.ts
+++ b/solana/web3.js-2.0/quicknode-addons/guide1.ts
@@ -6,7 +6,8 @@ import {
     createDefaultRpcTransport,
     createRpc,
     RpcTransport,
-    createRpcApi,
+    createJsonRpcApi, // note: in older versions of this library, this function was called: createRpcApi
+    RpcRequest,
     createSolanaRpcApi,
 } from "@solana/web3.js";
 import {
@@ -41,8 +42,8 @@ function createQuickNodeTransport({ endpoint }: createQuickNodeTransportParams):
  */
 export function createPriorityFeeApi(endpoint: string): Rpc<PriorityFeeApi> {
     const api0 = createSolanaRpcApi();
-    const api = createRpcApi<PriorityFeeApi>({
-        parametersTransformer: (params: any[]) => params[0],
+    const api = createJsonRpcApi<PriorityFeeApi>({
+        requestTransformer: (request: RpcRequest<any>) => request.params[0],
         responseTransformer: (response: any) => response.result,
     });
     const transport = createQuickNodeTransport({

--- a/solana/web3.js-2.0/quicknode-addons/guide2.ts
+++ b/solana/web3.js-2.0/quicknode-addons/guide2.ts
@@ -6,7 +6,8 @@ import {
     createDefaultRpcTransport,
     createRpc,
     RpcTransport,
-    createRpcApi,
+    createJsonRpcApi, // note: in older versions of this library, this function was called: createRpcApi,
+    RpcRequest
 } from "@solana/web3.js";
 import {
     EstimatePriorityFeesResponse,
@@ -133,8 +134,8 @@ interface CreateAddonsApiParams {
 
 
 export function createAddonsApi(params: CreateAddonsApiParams): Rpc<QuickNodeAddons> {
-    const api = createRpcApi<QuickNodeAddons>({
-        parametersTransformer: (params: unknown[]) => params[0],
+    const api = createJsonRpcApi<QuickNodeAddons>({
+        requestTransformer: (request: RpcRequest<any>) => request.params[0],
         responseTransformer: (response: any) => response.result,
     });
 


### PR DESCRIPTION
As of last week, v2 release candidate was dropped and is no longer experimental. Ref: https://github.com/solana-labs/solana-web3.js/releases Looks like with the release, a function was renamed. We are replacing the `createRpcApi` import with `createJsonRpcApi` and associated uses. Also one of the params changed as well.