### PR TITLE
add: jito polling delay

### DIFF
--- a/solana/jupiter-jito/index.ts
+++ b/solana/jupiter-jito/index.ts
@@ -26,7 +26,8 @@ const CONFIG = {
     WALLET_SECRET: process.env.WALLET_SECRET?.split(',').map(Number) || [],
     JITO_TIP_AMOUNT: 0.0005 * LAMPORTS_PER_SOL, // 500,000 lamports
     POLL_TIMEOUT_MS: 30000,
-    POLL_INTERVAL_MS: 3000
+    POLL_INTERVAL_MS: 3000,
+    DEFAULT_WAIT_BEFORE_POLL_MS: 5000
 };
 
 // Quote request configuration
@@ -52,6 +53,10 @@ class JitoSwapManager {
         this.jupiterApi = createJupiterApiClient({ basePath: CONFIG.METIS_ENDPOINT });
         this.wallet = Keypair.fromSecretKey(new Uint8Array(CONFIG.WALLET_SECRET));
         this.connection = new Connection(CONFIG.JITO_ENDPOINT);
+    }
+
+    private sleep(ms: number): Promise<void> {
+        return new Promise(resolve => setTimeout(resolve, ms));
     }
 
     async getSwapQuote(): Promise<QuoteResponse> {
@@ -115,6 +120,8 @@ class JitoSwapManager {
     }
 
     async pollBundleStatus(bundleId: string): Promise<boolean> {
+        await this.sleep(CONFIG.DEFAULT_WAIT_BEFORE_POLL_MS);
+
         const startTime = Date.now();
         let lastStatus = '';
         

--- a/solana/web3.js-2.0/jito-bundles/lilJit.ts
+++ b/solana/web3.js-2.0/jito-bundles/lilJit.ts
@@ -30,6 +30,9 @@ const SIMULATE_ONLY = true;
 const ENDPOINT = 'https://example.quiknode.pro/123456/'; // 👈 Replace with your own endpoint
 const POLL_INTERVAL_MS = 3000;
 const POLL_TIMEOUT_MS = 30000;
+const DEFAULT_WAIT_BEFORE_POLL_MS = 5000;
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 type JitoBundleSimulationResponse = {
     context: {
@@ -156,8 +159,11 @@ async function pollBundleStatus(
     rpc: Rpc<LilJitAddon>,
     bundleId: string,
     timeoutMs = 30000,
-    pollIntervalMs = 3000
+    pollIntervalMs = 3000,
+    waitBeforePollMs = DEFAULT_WAIT_BEFORE_POLL_MS
 ) {
+    await sleep(waitBeforePollMs);
+
     const startTime = Date.now();
     let lastStatus = '';
     while (Date.now() - startTime < timeoutMs) {
@@ -174,8 +180,7 @@ async function pollBundleStatus(
             }
 
             if (status === 'Failed') {
-                console.log(`Bundle ${status.toLowerCase()}. Exiting...`);
-                throw new Error(`Bundle failed with status: ${status}`);
+                throw new Error(`Bundle ${status.toLowerCase()} failed with status: ${status}`);
             }
 
             await new Promise(resolve => setTimeout(resolve, pollIntervalMs));


### PR DESCRIPTION
some users have latency between sending a bundle and polling seeing the bundle. add an optional delay for users to way before beginning polling project impacted:
- jupiter jito - `solana/jupiter-jito`
- jito sw3js2 - `solana/web3.js-2.0/jito-bundles`