### PR TITLE
add scaled ui amount guide

### DIFF
--- a/solana/token-extensions/scaled-ui-amount/README.md
+++ b/solana/token-extensions/scaled-ui-amount/README.md
@@ -1,0 +1,47 @@
+# Solana Scaled UI Amount Extension Demo
+
+A demonstration of the Solana Token-2022 Scaled UI Amount extension that allows token issuers to define a multiplier for how token balances are displayed without changing underlying raw amounts.
+
+## What's Included
+
+- **Web3.js (Legacy)**: Implementation using `@solana/web3.js` and `@solana/spl-token`
+- **Solana Kit**: Modern implementation using `@solana/kit` and related packages
+
+## Features Demonstrated
+
+- Creating tokens with the Scaled UI Amount extension
+- Minting and transferring tokens
+- Updating the UI multiplier
+- Observing the effects on raw vs. UI amounts
+
+## Requirements
+
+- Node.js v22+
+- Solana CLI v2.2+
+- Local Solana test validator
+
+## Quick Start
+
+1. Clone this repository
+2. Change to the `web3` or `kit` directory
+3. Install dependencies: `npm install`
+4. Create necessary private keys:
+
+```sh
+solana-keygen new -s --no-bip39-passphrase -o keys/payer.json && \
+solana-keygen new -s --no-bip39-passphrase -o keys/mint-authority.json && \
+solana-keygen new -s --no-bip39-passphrase -o keys/holder.json && \
+solana-keygen new -s --no-bip39-passphrase -o keys/mint.json
+```
+
+5. In a seperate terminal start a local validator: `solana-test-validator -r`
+6. In your original terminal, run the demo: `npm start`
+
+## How It Works
+
+The demo performs a sequence of operations showing how the UI amount scales with the multiplier while raw amounts remain unchanged. After running, view the summary table showing the relationship between raw balances and UI amounts throughout the process.
+
+## Learn More
+
+For detailed implementation steps and explanations, visit the full guide:
+[Using Scaled UI Amount Token Extension on Solana](https://www.quicknode.com/guides/solana-development/spl-tokens/token-2022/scaled-ui-amount)

--- a/solana/token-extensions/scaled-ui-amount/kit/package.json
+++ b/solana/token-extensions/scaled-ui-amount/kit/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "solana-scaled-token-creator",
+  "version": "1.0.0",
+  "description": "A script for creating and testing Solana SPL tokens with the Token-2022 Scaled UI Amount extension",
+  "main": "token-creator.js",
+  "scripts": {
+    "start": "ts-node token-creator.ts",
+    "build": "tsc",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "solana",
+    "spl-token",
+    "token-2022",
+    "blockchain",
+    "cryptocurrency"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@solana-program/system": "^0.7.0",
+    "@solana-program/token-2022": "^0.4.1",
+    "@solana/kit": "^2.1.1"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.1.6"
+  }
+}

--- a/solana/token-extensions/scaled-ui-amount/kit/token-creator.ts
+++ b/solana/token-extensions/scaled-ui-amount/kit/token-creator.ts
@@ -1,0 +1,491 @@
+import { getCreateAccountInstruction } from '@solana-program/system';
+import {
+    extension,
+    Extension,
+    ExtensionArgs,
+    findAssociatedTokenPda,
+    getCreateAssociatedTokenIdempotentInstructionAsync,
+    getInitializeMintInstruction,
+    getMintSize,
+    getMintToInstruction,
+    getPostInitializeInstructionsForMintExtensions,
+    getPreInitializeInstructionsForMintExtensions,
+    getUpdateMultiplierScaledUiMintInstruction,
+    getTransferInstruction,
+    fetchMint,
+    TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
+import {
+    airdropFactory,
+    createSolanaRpc,
+    createSolanaRpcSubscriptions,
+    generateKeyPairSigner,
+    lamports,
+    Rpc,
+    sendAndConfirmTransactionFactory,
+    pipe,
+    createTransactionMessage,
+    setTransactionMessageLifetimeUsingBlockhash,
+    setTransactionMessageFeePayerSigner,
+    appendTransactionMessageInstructions,
+    createKeyPairSignerFromBytes,
+    KeyPairSigner,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+    RpcSubscriptions,
+    Signature,
+    Address,
+    TransactionSigner,
+    IInstruction,
+    Commitment,
+    signTransactionMessageWithSigners,
+    CompilableTransactionMessage,
+    TransactionMessageWithBlockhashLifetime,
+    getSignatureFromTransaction,
+} from "@solana/kit"
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const CONFIG = {
+    DECIMAL_PLACES: 6,
+    INITIAL_UI_AMOUNT_MULTIPLIER: 1.0,
+    MODIFIED_UI_AMOUNT_MULTIPLIER: 2.0,
+    TOKEN_NAME: "Scaled Demo Token",
+    TOKEN_SYMBOL: "SDT",
+    MINT_AMOUNT: 100,
+    TRANSFER_AMOUNT: 10,
+    HTTP_CONNECTION_URL: 'http://127.0.0.1:8899',
+    WSS_CONNECTION_URL: 'ws://127.0.0.1:8900',
+    KEYPAIR_DIR: path.join(__dirname, 'keys')
+};
+const LAMPORTS_PER_SOL = BigInt(1_000_000_000);
+
+interface StatusLog {
+    step: string;
+    timestamp: string;
+    multiplier: number;
+    rawBalance: string;
+    uiBalance: string;
+    description: string;
+}
+
+interface Client {
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+}
+
+const demoLogs: StatusLog[] = [];
+
+async function getTokenMultiplier(
+    client: Client,
+    mintAddress: Address
+): Promise<number> {
+    try {
+        const mint = await fetchMint(client.rpc, mintAddress);
+        if (!mint.data.extensions || mint.data.extensions.__option === 'None') {
+            return 1.0; // Default if no extensions
+        }
+        
+        const extensionArray = mint.data.extensions.__option === 'Some' ? mint.data.extensions.value : [];
+        const extensionData = extensionArray.find(
+            (ext: Extension) => ext.__kind === 'ScaledUiAmountConfig'
+        );
+        
+        if (!extensionData) {
+            return 1.0; // Default if no extension data
+        } else {
+            const currentTime = new Date().getTime();
+            if (Number(extensionData.newMultiplierEffectiveTimestamp) < currentTime) {
+                return extensionData.newMultiplier;
+            } else {
+                return extensionData.multiplier;
+            }
+        }
+    } catch (error) {
+        console.error('Error getting token multiplier:', error);
+        return 1.0; // Default on error
+    }
+}
+
+async function logStatus(
+    client: Client,
+    step: string,
+    mintAddress: Address,
+    tokenAccount: Address | null,
+    description: string
+): Promise<void> {
+    const now = new Date();
+    const timestamp = now.toLocaleTimeString();
+
+    const multiplier = await getTokenMultiplier(client, mintAddress);
+    let rawBalance = 'n/a';
+    let uiBalance = 'n/a';
+
+    if (tokenAccount) {
+        const balance = await client.rpc.getTokenAccountBalance(tokenAccount).send();
+        rawBalance = balance.value.amount;
+        uiBalance = balance.value.uiAmountString;
+    }
+
+    demoLogs.push({
+        step,
+        timestamp,
+        multiplier,
+        rawBalance,
+        uiBalance,
+        description
+    });
+}
+
+function printSummaryTable(): void {
+    console.log("\n=== DEMONSTRATION SUMMARY ===");
+    console.table(demoLogs.map(log => ({
+        Step: log.step,
+        Timestamp: log.timestamp,
+        Multiplier: log.multiplier,
+        "Raw Balance": log.rawBalance,
+        "UI Balance": log.uiBalance
+    })));
+}
+
+async function getOrCreateKeypairSigner(keyPath: string, label: string): Promise<KeyPairSigner<string>> {
+    try {
+        if (!fs.existsSync(keyPath)) {
+            throw new Error(`Keypair file not found: ${keyPath}`);
+        }
+        const keyData = JSON.parse(fs.readFileSync(keyPath, 'utf-8'));
+        const keypair = await createKeyPairSignerFromBytes(new Uint8Array(keyData));
+        return keypair;
+    } catch (error) {
+        const keypair = await generateKeyPairSigner();
+        console.log(`Generated new ${label} keypair as fallback: ${keypair.address}`);
+        return keypair;
+    }
+}
+
+
+
+
+export const createDefaultTransaction = async (
+    client: Client,
+    feePayer: TransactionSigner
+) => {
+    const { value: latestBlockhash } = await client.rpc
+        .getLatestBlockhash()
+        .send();
+    return pipe(
+        createTransactionMessage({ version: 0 }),
+        (tx) => setTransactionMessageFeePayerSigner(feePayer, tx),
+        (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx)
+    );
+};
+export const signAndSendTransaction = async (
+    client: Client,
+    transactionMessage: CompilableTransactionMessage &
+        TransactionMessageWithBlockhashLifetime,
+    commitment: Commitment = 'confirmed'
+) => {
+    const signedTransaction =
+        await signTransactionMessageWithSigners(transactionMessage);
+    const signature = getSignatureFromTransaction(signedTransaction);
+    await sendAndConfirmTransactionFactory(client)(signedTransaction, {
+        commitment,
+    });
+    return signature;
+};
+export const sendAndConfirmInstructions = async (
+    client: Client,
+    payer: TransactionSigner,
+    instructions: IInstruction[]
+) => {
+    const signature = await pipe(
+        await createDefaultTransaction(client, payer),
+        (tx) => appendTransactionMessageInstructions(instructions, tx),
+        (tx) => signAndSendTransaction(client, tx)
+    );
+    return signature;
+};
+
+
+async function setup(client: Client, payer: KeyPairSigner<string>) {
+    try {
+        const airdrop = airdropFactory({ rpc: client.rpc, rpcSubscriptions: client.rpcSubscriptions });
+        const airdropTx: Signature = await airdrop({
+            commitment: 'processed',
+            lamports: lamports(LAMPORTS_PER_SOL),
+            recipientAddress: payer.address
+        });
+        console.log(` ✅ Transaction airdrop confirmed: ${airdropTx}`);
+    } catch (error) {
+        console.error(' ❌ Error funding payer account');
+    }
+}
+
+const getCreateMintInstructions = async (input: {
+    authority: Address;
+    client: Client;
+    decimals?: number;
+    extensions?: ExtensionArgs[];
+    freezeAuthority?: Address;
+    mint: TransactionSigner;
+    payer: TransactionSigner;
+    programAddress?: Address;
+}) => {
+    const space = getMintSize(input.extensions);
+    const postInitializeExtensions: Extension['__kind'][] = [
+        'TokenMetadata',
+        'TokenGroup',
+        'TokenGroupMember',
+    ];
+    const spaceWithoutPostInitializeExtensions = input.extensions
+        ? getMintSize(
+            input.extensions.filter(
+                (e) => !postInitializeExtensions.includes(e.__kind)
+            )
+        )
+        : space;
+    const rent = await input.client.rpc
+        .getMinimumBalanceForRentExemption(BigInt(space))
+        .send();
+    return [
+        getCreateAccountInstruction({
+            payer: input.payer,
+            newAccount: input.mint,
+            lamports: rent,
+            space: spaceWithoutPostInitializeExtensions,
+            programAddress: input.programAddress ?? TOKEN_2022_PROGRAM_ADDRESS,
+        }),
+        getInitializeMintInstruction({
+            mint: input.mint.address,
+            decimals: input.decimals ?? 0,
+            freezeAuthority: input.freezeAuthority,
+            mintAuthority: input.authority,
+        }),
+    ];
+};
+
+
+const createScaledToken = async (
+    input: Omit<
+        Parameters<typeof getCreateMintInstructions>[0],
+        'authority' | 'mint'
+    > & {
+        authority: TransactionSigner;
+        mint?: TransactionSigner;
+    }
+): Promise<Address> => {
+    const mint = input.mint ?? (await generateKeyPairSigner());
+    const [createAccount, initMint] = await getCreateMintInstructions({
+        ...input,
+        authority: input.authority.address,
+        mint,
+    });
+    const createMintSignature = await sendAndConfirmInstructions(input.client, input.payer, [
+        createAccount,
+        ...getPreInitializeInstructionsForMintExtensions(
+            mint.address,
+            input.extensions ?? []
+        ),
+        initMint,
+        ...getPostInitializeInstructionsForMintExtensions(
+            mint.address,
+            input.authority,
+            input.extensions ?? []
+        ),
+    ]);
+    console.log(` ✅ Token created! Transaction signature: ${createMintSignature}`);
+    console.log(`    Mint address: ${mint.address}`);
+
+    return mint.address;
+};
+
+async function createAta(client: Client, payer: TransactionSigner, mint: TransactionSigner, owner: TransactionSigner): Promise<Address> {
+    const createAta = await getCreateAssociatedTokenIdempotentInstructionAsync({
+        payer,
+        mint: mint.address,
+        owner: owner.address,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+    });
+    await sendAndConfirmInstructions(client, payer, [createAta]);
+    const [ata] = await findAssociatedTokenPda({
+        mint: mint.address,
+        owner: owner.address,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    });
+    console.log(` ✅ Associated token account created: ${ata}`);
+    return ata;
+}
+
+async function transferTokens(client: Client, payer: TransactionSigner, source: Address, sourceOwner: TransactionSigner, mint: TransactionSigner, amount: bigint) {
+    try {
+        const destination = await generateKeyPairSigner();
+        const destinationTokenAccount = await createAta(client, payer, mint, destination);
+        const transferInstruction = getTransferInstruction({
+            source: source,
+            destination: destinationTokenAccount,
+            authority: sourceOwner,
+            amount: amount,
+        }, {
+            programAddress: TOKEN_2022_PROGRAM_ADDRESS
+        });
+        const txid = await sendAndConfirmInstructions(client, payer, [transferInstruction]);
+        console.log(` ✅ Transfer transaction confirmed: ${txid}`);
+        return txid;
+    } catch (error) {
+        console.error(' ❌ Error transferring tokens');
+        throw error;
+    }
+}
+
+
+async function mintTokens(client: Client, payer: TransactionSigner, mintAuthority: TransactionSigner,mint: TransactionSigner,  tokenAccount: Address, amount: bigint) {
+    try {
+        const mintToInstruction = getMintToInstruction({
+            mint: mint.address,
+            token: tokenAccount,
+            amount,
+            mintAuthority
+        }, {
+            programAddress: TOKEN_2022_PROGRAM_ADDRESS
+        });
+        const txid = await sendAndConfirmInstructions(client, payer, [mintToInstruction]);
+        console.log(` ✅ Mint transaction confirmed: ${txid}`);
+        return txid;
+    } catch (error) {
+        console.error(' ❌ Error minting tokens');
+        throw error;
+    }
+}
+
+async function updateMultiplier(client: Client, payer: TransactionSigner, mint: TransactionSigner, mintAuthority: TransactionSigner, newMultiplier: number) {
+    try {
+        const updateMultiplierInstruction = getUpdateMultiplierScaledUiMintInstruction({
+            mint: mint.address,
+            authority: mintAuthority,
+            effectiveTimestamp: BigInt(0),
+            multiplier: newMultiplier,
+        }, {
+            programAddress: TOKEN_2022_PROGRAM_ADDRESS
+        });
+        const txid = await sendAndConfirmInstructions(client, payer, [updateMultiplierInstruction]);
+        console.log(` ✅ Update multiplier transaction confirmed: ${txid}`);
+        return txid;
+    } catch (error) {
+        console.error(' ❌ Error updating multiplier');
+        throw error;
+    }
+}
+
+
+async function demonstrateScaledToken(): Promise<void> {
+    try {
+        console.log(`=== SCALED TOKEN DEMONSTRATION ===`);
+        console.log(`\n=== Setup ===`);
+
+        const client: Client = {
+            rpc: createSolanaRpc(CONFIG.HTTP_CONNECTION_URL),
+            rpcSubscriptions: createSolanaRpcSubscriptions(CONFIG.WSS_CONNECTION_URL)
+        };
+
+        const payer = await getOrCreateKeypairSigner(path.join(CONFIG.KEYPAIR_DIR, 'payer.json'), 'payer');
+        const mintAuthority = await getOrCreateKeypairSigner(path.join(CONFIG.KEYPAIR_DIR, 'mint-authority.json'), 'mint authority');
+        const mint = await getOrCreateKeypairSigner(path.join(CONFIG.KEYPAIR_DIR, 'mint.json'), 'mint');
+        const holder = await getOrCreateKeypairSigner(path.join(CONFIG.KEYPAIR_DIR, 'holder.json'), 'token holder');
+        await setup(client, payer);
+
+        console.log(`\n=== Step 1: Creating Token Mint ===`);
+        const mintAddress = await createScaledToken({
+            authority: mintAuthority,
+            client,
+            extensions: [
+                extension('ScaledUiAmountConfig', {
+                    authority: mintAuthority.address,
+                    multiplier: CONFIG.INITIAL_UI_AMOUNT_MULTIPLIER,
+                    newMultiplierEffectiveTimestamp: BigInt(0),
+                    newMultiplier: CONFIG.INITIAL_UI_AMOUNT_MULTIPLIER,
+                }),
+            ],
+            payer: payer,
+            mint
+        });
+        await logStatus(
+            client,
+            "1. Token Created",
+            mintAddress,
+            null,
+            "Token created with Scaled UI Amount extension"
+        );
+        console.log(`\n=== Step 2: Creating Holder's Token Account ===`);
+        const holderTokenAccount = await createAta(client, payer, mint, holder);
+        await logStatus(
+            client,
+            "2. Ata Created",
+            mint.address,
+            holderTokenAccount,
+            "Holder's token account created"
+        );
+
+        console.log(`\n=== Step 3: Minting Initial Tokens ===`);
+        await mintTokens(client, payer, mintAuthority, mint, holderTokenAccount, BigInt(CONFIG.MINT_AMOUNT));
+        await logStatus(
+            client,
+            "3. After Mint #1",
+            mint.address,
+            holderTokenAccount,
+            "Initial tokens minted"
+        );
+
+        console.log(`\n=== Step 4: Transferring Tokens ===`);
+        await transferTokens(client, payer, holderTokenAccount, holder, mint, BigInt(CONFIG.TRANSFER_AMOUNT));
+        await logStatus(
+            client,
+            "4. After Transfer",
+            mint.address,
+            holderTokenAccount,
+            "Tokens transferred"
+        );
+
+        console.log(`\n=== Step 5: Updating Scale Multiplier ===`);
+        await updateMultiplier(client, payer, mint, mintAuthority, CONFIG.MODIFIED_UI_AMOUNT_MULTIPLIER);
+        await logStatus(
+            client,
+            "5. After Update Multiplier",
+            mint.address,
+            holderTokenAccount,
+            "Multiplier updated"
+        );
+        console.log(`\n=== Step 6: Minting Additional Tokens ===`);
+        await mintTokens(client, payer, mintAuthority, mint, holderTokenAccount, BigInt(CONFIG.MINT_AMOUNT));
+        await logStatus(
+            client,
+            "6. After Mint #2",
+            mint.address,
+            holderTokenAccount,
+            "Additional tokens minted"
+        );
+
+        console.log(`\n=== Step 7: Transferring Additional Tokens ===`);
+        await transferTokens(client, payer, holderTokenAccount, holder, mint, BigInt(CONFIG.TRANSFER_AMOUNT));
+        await logStatus(
+            client,
+            "7. After Transfer #2",
+            mint.address,
+            holderTokenAccount,
+            "Additional tokens transferred"
+        );
+
+        printSummaryTable();
+    }
+    catch (error) {
+
+    }
+}
+
+if (require.main === module) {
+    console.log('Starting the Token-2022 Scaled UI Amount demonstration...');
+    demonstrateScaledToken()
+        .then(() => console.log(`=== DEMONSTRATION COMPLETED ===`))
+        .catch(error => console.error('Demonstration failed with error:', error));
+}
+

--- a/solana/token-extensions/scaled-ui-amount/kit/tsconfig.json
+++ b/solana/token-extensions/scaled-ui-amount/kit/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "lib": ["es2020"],
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/solana/token-extensions/scaled-ui-amount/web3/package.json
+++ b/solana/token-extensions/scaled-ui-amount/web3/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "solana-scaled-token-creator",
+  "version": "1.0.0",
+  "description": "A script for creating and testing Solana SPL tokens with the Token-2022 Scaled UI Amount extension",
+  "main": "token-creator.js",
+  "scripts": {
+    "start": "ts-node token-creator.ts",
+    "build": "tsc",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "solana",
+    "spl-token",
+    "token-2022",
+    "blockchain",
+    "cryptocurrency"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@solana/spl-token": "^0.4.13",
+    "@solana/web3.js": "^1.98.2"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.1.6"
+  }
+}

--- a/solana/token-extensions/scaled-ui-amount/web3/token-creator.ts
+++ b/solana/token-extensions/scaled-ui-amount/web3/token-creator.ts
@@ -1,0 +1,486 @@
+import {
+    Connection,
+    Keypair,
+    LAMPORTS_PER_SOL,
+    PublicKey,
+    SystemProgram,
+    Transaction,
+    sendAndConfirmTransaction
+  } from '@solana/web3.js';
+  
+  import {
+    ExtensionType,
+    TOKEN_2022_PROGRAM_ID,
+    createInitializeMintInstruction,
+    createInitializeScaledUiAmountConfigInstruction,
+    getMintLen,
+    getOrCreateAssociatedTokenAccount,
+    mintTo,
+    updateMultiplier,
+    getScaledUiAmountConfig,
+    unpackMint,
+    createTransferInstruction
+  } from '@solana/spl-token';
+  
+  import * as fs from 'fs';
+  import * as path from 'path';
+  
+  const CONFIG = {
+    DECIMAL_PLACES: 6,
+    INITIAL_UI_AMOUNT_MULTIPLIER: 1.0,
+    MODIFIED_UI_AMOUNT_MULTIPLIER: 2.0,
+    TOKEN_NAME: "Scaled Demo Token",
+    TOKEN_SYMBOL: "SDT",
+    MINT_AMOUNT: 100,
+    TRANSFER_AMOUNT: 10,
+    CONNECTION_URL: 'http://127.0.0.1:8899',
+    KEYPAIR_DIR: path.join(__dirname, 'keys')
+  };
+  
+  interface StatusLog {
+    step: string;
+    timestamp: string;
+    multiplier: number;
+    rawBalance: string;
+    uiBalance: string;
+    description: string;
+  }
+  
+  const demoLogs: StatusLog[] = [];
+  
+  async function getTokenMultiplier(
+    connection: Connection,
+    mintPublicKey: PublicKey
+  ): Promise<number> {
+    const mintInfo = await connection.getAccountInfo(mintPublicKey);
+    if (!mintInfo) {
+      throw new Error(`Mint account not found: ${mintPublicKey.toString()}`);
+    }
+  
+    const unpackedMint = unpackMint(mintPublicKey, mintInfo, TOKEN_2022_PROGRAM_ID);
+    const extensionData = getScaledUiAmountConfig(unpackedMint);
+    if (!extensionData) {
+      return 1.0; // Default if no extension data
+    } else {
+      const currentTime = new Date().getTime();
+      if (Number(extensionData.newMultiplierEffectiveTimestamp) < currentTime) {
+        return extensionData.newMultiplier;
+      } else {
+        return extensionData.multiplier;
+      }
+    }
+  }
+  
+  async function getTokenBalance(
+    connection: Connection,
+    tokenAccount: PublicKey,
+  ): Promise<{ rawAmount: string, uiAmount: string }> {
+    try {
+      const balanceDetail = await connection.getTokenAccountBalance(tokenAccount);
+      return {
+        rawAmount: balanceDetail.value.amount,
+        uiAmount: balanceDetail.value.uiAmountString || '0'
+      };
+    } catch (error) {
+      return {
+        rawAmount: 'n/a',
+        uiAmount: 'n/a'
+      };
+    }
+  }
+  
+  async function logStatus(
+    connection: Connection,
+    step: string,
+    mintPublicKey: PublicKey,
+    tokenAccount: PublicKey | null,
+    description: string
+  ): Promise<void> {
+    const now = new Date();
+    const timestamp = now.toLocaleTimeString();
+  
+    const multiplier = await getTokenMultiplier(connection, mintPublicKey);
+  
+    let rawBalance = 'n/a';
+    let uiBalance = 'n/a';
+  
+    if (tokenAccount) {
+      const balance = await getTokenBalance(connection, tokenAccount);
+      rawBalance = balance.rawAmount;
+      uiBalance = balance.uiAmount;
+    }
+  
+    demoLogs.push({
+      step,
+      timestamp,
+      multiplier,
+      rawBalance,
+      uiBalance,
+      description
+    });
+  }
+  
+  function printSummaryTable(): void {
+    console.log("\n=== DEMONSTRATION SUMMARY ===");
+    console.table(demoLogs.map(log => ({
+      Step: log.step,
+      Timestamp: log.timestamp,
+      Multiplier: log.multiplier,
+      "Raw Balance": log.rawBalance,
+      "UI Balance": log.uiBalance
+    })));
+  }
+  
+  async function waitForTransaction(
+    connection: Connection,
+    signature: string,
+    timeout = 30000,
+    transactionNote: string
+  ): Promise<string> {
+    const startTime = Date.now();
+    return new Promise((resolve, reject) => {
+      (async () => {
+        try {
+          let done = false;
+          while (!done && Date.now() - startTime < timeout) {
+            const status = await connection.getSignatureStatus(signature);
+  
+            if (status?.value?.confirmationStatus === 'confirmed' ||
+              status?.value?.confirmationStatus === 'finalized') {
+              done = true;
+              console.log(` ✅ Transaction ${transactionNote} confirmed: ${signature}`);
+              resolve(signature);
+            } else {
+              await new Promise(resolve => setTimeout(resolve, 1000));
+            }
+          }
+  
+          if (!done) {
+            reject(new Error(` ❌ Transaction confirmation timeout after ${timeout}ms`));
+          }
+        } catch (error) {
+          reject(error);
+        }
+      })();
+    });
+  }
+  
+  async function getOrCreateKeypair(keyPath: string, label: string): Promise<Keypair> {
+    try {
+      if (fs.existsSync(keyPath)) {
+        const keyData = JSON.parse(fs.readFileSync(keyPath, 'utf-8'));
+        const keypair = Keypair.fromSecretKey(new Uint8Array(keyData));
+        return keypair;
+      } else {
+        const keypair = Keypair.generate();
+        fs.writeFileSync(keyPath, JSON.stringify(Array.from(keypair.secretKey)));
+        return keypair;
+      }
+    } catch (error) {
+      const keypair = Keypair.generate();
+      console.log(`Generated new ${label} keypair as fallback: ${keypair.publicKey.toString()}`);
+      return keypair;
+    }
+  }
+  
+  async function setup(connection: Connection, payer: Keypair) {
+    try {
+      const airdropSignature = await connection.requestAirdrop(
+        payer.publicKey,
+        2 * LAMPORTS_PER_SOL
+      );
+      await waitForTransaction(connection, airdropSignature, 30000, "airdrop");
+    } catch (error) {
+      console.error('Error funding payer account:', error);
+      console.log('If you are not using a local validator, you need to fund the payer account manually.');
+    }
+  }
+  
+  async function createScaledToken(connection: Connection, payer: Keypair, mint: Keypair, mintAuthority: Keypair) {
+    try {
+      // Calculate space needed for the mint account with Scaled UI Amount extension
+      const extensions = [ExtensionType.ScaledUiAmountConfig];
+      const mintLen = getMintLen(extensions);
+  
+      // Calculate lamports needed for rent-exemption
+      const mintLamports = await connection.getMinimumBalanceForRentExemption(mintLen);
+  
+      // Create a new token with Token-2022 program & Scaled UI Amount extension
+      const transaction = new Transaction().add(
+        // Create account for the mint
+        SystemProgram.createAccount({
+          fromPubkey: payer.publicKey,
+          newAccountPubkey: mint.publicKey,
+          space: mintLen,
+          lamports: mintLamports,
+          programId: TOKEN_2022_PROGRAM_ID,
+        }),
+        // Initialize Scaled UI Amount extension
+        createInitializeScaledUiAmountConfigInstruction(
+          mint.publicKey,
+          mintAuthority.publicKey,
+          CONFIG.INITIAL_UI_AMOUNT_MULTIPLIER,
+          TOKEN_2022_PROGRAM_ID
+        ),
+        // Initialize the mint
+        createInitializeMintInstruction(
+          mint.publicKey,
+          CONFIG.DECIMAL_PLACES,
+          mintAuthority.publicKey,
+          mintAuthority.publicKey,
+          TOKEN_2022_PROGRAM_ID
+        )
+      );
+  
+      const createMintSignature = await sendAndConfirmTransaction(
+        connection,
+        transaction,
+        [payer, mint],
+        { commitment: 'confirmed' }
+      );
+  
+      console.log(` ✅ Token created! Transaction signature: ${createMintSignature}`);
+      console.log(`    Mint address: ${mint.publicKey.toString()}`);
+  
+      return;
+    } catch (error) {
+      console.error('Error creating token:', error);
+      throw error;
+    }
+  }
+  
+  async function updateScaledUiAmountMultiplier(
+    connection: Connection,
+    mint: Keypair,
+    mintAuthority: Keypair,
+    payer: Keypair,
+    newMultiplier: number,
+    startTimestamp: number = 0 // default, 0, is effective immediately
+  ): Promise<string> {
+    try {
+      const signature = await updateMultiplier(
+        connection,
+        payer,
+        mint.publicKey,
+        mintAuthority,
+        newMultiplier,
+        BigInt(startTimestamp),
+        [payer, mintAuthority],
+        undefined,
+        TOKEN_2022_PROGRAM_ID
+      );
+  
+      await waitForTransaction(connection, signature, 30000, "multiplier update");
+  
+      console.log(` UI amount multiplier updated! Transaction signature: ${signature}`);
+  
+      return signature;
+    } catch (error) {
+      console.error(' Error updating UI amount multiplier:', error);
+      throw error;
+    }
+  }
+  
+  async function transferTokens(
+    connection: Connection,
+    payer: Keypair,
+    source: PublicKey,
+    sourceOwner: Keypair,
+    mint: PublicKey
+  ): Promise<string> {
+    try {
+      const amount = CONFIG.TRANSFER_AMOUNT * (10 ** CONFIG.DECIMAL_PLACES);
+  
+      const destinationOwner = Keypair.generate();
+      const destinationAccount = await getOrCreateAssociatedTokenAccount(
+        connection,
+        payer,
+        mint,
+        destinationOwner.publicKey,
+        false,
+        'confirmed',
+        {},
+        TOKEN_2022_PROGRAM_ID
+      );
+  
+      const tx = new Transaction().add(
+        createTransferInstruction(
+          source,
+          destinationAccount.address,
+          sourceOwner.publicKey,
+          amount,
+          [sourceOwner],
+          TOKEN_2022_PROGRAM_ID
+        )
+      );
+  
+      const transferSignature = await sendAndConfirmTransaction(
+        connection,
+        tx,
+        [payer, sourceOwner],
+        { commitment: 'confirmed' }
+      );
+  
+      console.log(` ✅ Tokens transferred! Transaction signature: ${transferSignature}`);
+  
+      return transferSignature;
+    } catch (error) {
+      console.error(' ❌ Error transferring tokens');
+      throw error;
+    }
+  }
+  
+  async function demonstrateScaledToken(): Promise<void> {
+    try {
+      console.log(`=== SCALED TOKEN DEMONSTRATION ===`);
+      console.log(`\n=== Setup ===`);
+      const connection = new Connection(CONFIG.CONNECTION_URL, 'confirmed');
+      const payer = await getOrCreateKeypair(path.join(CONFIG.KEYPAIR_DIR, 'payer.json'), 'payer');
+      const mintAuthority = await getOrCreateKeypair(path.join(CONFIG.KEYPAIR_DIR, 'mint-authority.json'), 'mint authority');
+      const mint = await getOrCreateKeypair(path.join(CONFIG.KEYPAIR_DIR, 'mint.json'), 'mint');
+      const holder = await getOrCreateKeypair(path.join(CONFIG.KEYPAIR_DIR, 'holder.json'), 'token holder');
+      await setup(connection, payer);
+  
+      console.log(`\n=== Step 1: Creating Token Mint ===`);
+      await createScaledToken(connection, payer, mint, mintAuthority);
+  
+      await logStatus(
+        connection,
+        "Initial Setup",
+        mint.publicKey,
+        null,
+        "Token created with Scaled UI Amount extension"
+      );
+  
+      console.log(`\n=== Step 2: Creating Holder's Token Account ===`);
+      const holderTokenAccount = await getOrCreateAssociatedTokenAccount(
+        connection,
+        payer,
+        mint.publicKey,
+        holder.publicKey,
+        false,
+        'confirmed',
+        {},
+        TOKEN_2022_PROGRAM_ID
+      );
+  
+      console.log(` ✅ Holder's token account created: ${holderTokenAccount.address.toString()}`);
+      await logStatus(
+        connection,
+        "After ATA Created",
+        mint.publicKey,
+        holderTokenAccount.address,
+        "Holder's token account created"
+      );
+  
+      console.log(`\n=== Step 3: Minting Initial Tokens ===`);
+      const initialMintAmount = CONFIG.MINT_AMOUNT * (10 ** CONFIG.DECIMAL_PLACES);
+  
+      const mintToSignature = await mintTo(
+        connection,
+        payer,
+        mint.publicKey,
+        holderTokenAccount.address,
+        mintAuthority,
+        initialMintAmount,
+        [],
+        {},
+        TOKEN_2022_PROGRAM_ID
+      );
+  
+      await waitForTransaction(connection, mintToSignature, 30000, "initial mint");
+  
+      await logStatus(
+        connection,
+        "After Mint #1",
+        mint.publicKey,
+        holderTokenAccount.address,
+        `Minted ${CONFIG.MINT_AMOUNT} tokens with initial multiplier`
+      );
+  
+      console.log(`\n=== Step 4: Transferring Tokens ===`);
+      await transferTokens(
+        connection,
+        payer,
+        holderTokenAccount.address,
+        holder,
+        mint.publicKey
+      );
+  
+      await logStatus(
+        connection,
+        "After Transfer #1",
+        mint.publicKey,
+        holderTokenAccount.address,
+        `Transferred ${CONFIG.TRANSFER_AMOUNT} tokens to another account`
+      );
+  
+      console.log(`\n=== Step 5: Updating Scale Multiplier ===`);
+      await updateScaledUiAmountMultiplier(
+        connection,
+        mint,
+        mintAuthority,
+        payer,
+        CONFIG.MODIFIED_UI_AMOUNT_MULTIPLIER
+      );
+  
+      await logStatus(
+        connection,
+        "After Multiplier Update",
+        mint.publicKey,
+        holderTokenAccount.address,
+        `Updated multiplier to ${CONFIG.MODIFIED_UI_AMOUNT_MULTIPLIER}x`
+      );
+  
+      console.log(`\n=== Step 6: Minting Additional Tokens ===`);
+      const additionalMintSignature = await mintTo(
+        connection,
+        payer,
+        mint.publicKey,
+        holderTokenAccount.address,
+        mintAuthority,
+        initialMintAmount, // Same raw amount as before
+        [],
+        {},
+        TOKEN_2022_PROGRAM_ID
+      );
+  
+      await waitForTransaction(connection, additionalMintSignature, 30000, "additional mint");
+  
+      await logStatus(
+        connection,
+        "After Mint #2",
+        mint.publicKey,
+        holderTokenAccount.address,
+        `Minted additional ${CONFIG.MINT_AMOUNT} tokens with current multiplier`
+      );
+  
+      console.log(`\n=== Step 7: Transferring Additional Tokens ===`);
+      await transferTokens(
+        connection,
+        payer,
+        holderTokenAccount.address,
+        holder,
+        mint.publicKey
+      );
+  
+      await logStatus(
+        connection,
+        "After Transfer #2",
+        mint.publicKey,
+        holderTokenAccount.address,
+        `Transferred ${CONFIG.TRANSFER_AMOUNT} tokens to another account (with multiplier)`
+      );
+  
+      printSummaryTable();
+    } catch (error) {
+      console.error('Error in scaled token demonstration:', error);
+    }
+  }
+  
+  if (require.main === module) {
+    console.log('Starting the Token-2022 Scaled UI Amount demonstration...');
+    demonstrateScaledToken()
+      .then(() => console.log(`=== DEMONSTRATION COMPLETED ===`))
+      .catch(error => console.error('Demonstration failed with error:', error));
+  }

--- a/solana/token-extensions/scaled-ui-amount/web3/tsconfig.json
+++ b/solana/token-extensions/scaled-ui-amount/web3/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "lib": ["es2020"],
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
adds solana web3.js code and solana kit for for upcoming guide (not yet live: https://www.quicknode.com/guides/solana-development/spl-tokens/token-2022/scaled-ui-amount) 

Code deomonstrates the Solana Token-2022 Scaled UI Amount extension that allows token issuers to experiment with multiplier and SPL token basics (e.g. minting and transferring). 