### PR TITLE
fix: deploy script - OutOfFunds error

### DIFF
--- a/ethereum/eip-7702/script/BatchCallAndSponsor.s.sol
+++ b/ethereum/eip-7702/script/BatchCallAndSponsor.s.sol
@@ -41,6 +41,7 @@ contract BatchCallAndSponsorScript is Script {
         token = new MockERC20();
 
         // // Fund accounts
+        vm.deal(ALICE_ADDRESS, 10 ether);
         token.mint(ALICE_ADDRESS, 1000e18);
 
         vm.stopBroadcast();


### PR DESCRIPTION
when i run  forge script ./script/BatchCallAndSponsor.s.sol --tc BatchCallAndSponsorScript --broadcast 
i get this error:
![image](https://github.com/user-attachments/assets/d992d042-a7c8-45ba-ae7c-3d8ba80059cc)
but when i add   `vm.deal(ALICE_ADDRESS, 10 ether);`  i don't get the error