### PR TITLE
Add new Solana types for new Solana Kit code examples

### DIFF
--- a/solana/priority-fees-addon/types.ts
+++ b/solana/priority-fees-addon/types.ts
@@ -52,19 +52,6 @@ interface RequestPayload {
     recommended: number;
   }
   
-  interface SolanaKitEstimatePriorityFeesResponse {
-    id: string;
-    jsonrpc: string;
-    result: {
-      context: {
-          slot: number;
-      };
-      per_compute_unit: FeeEstimates;
-      per_transaction: FeeEstimates;
-      recommended: number;
-    };
-  }
-  
   interface SolanaKitEstimatePriorityFeesParams {
     last_n_blocks?: number;
     account?: string;
@@ -77,7 +64,6 @@ interface RequestPayload {
     ResponseData,
     EstimatePriorityFeesParams,
     EstimatePriorityFeesResponse, 
-    SolanaKitEstimatePriorityFeesParams,
-    SolanaKitEstimatePriorityFeesResponse
+    SolanaKitEstimatePriorityFeesParams
   };
   


### PR DESCRIPTION
From this [PR](https://github.com/quiknode-labs/docs/pull/2296), I've added new code examples that uses Solana Kit library. However, the Solana Kit library has different input and output params for the QuickNode's priority fee method. Therefore, the following new interfaces are needed. 