### PR TITLE
[CON-716] Add DFlow Kalshi Prediction Markets to Examples Repo

### DIFF
--- a/solana/kalshi-dflow/.env.example
+++ b/solana/kalshi-dflow/.env.example
@@ -1,0 +1,7 @@
+METADATA_API_URL=https://dev-prediction-markets-api.dflow.net
+TRADE_API_URL=https://dev-quote-api.dflow.net
+DFLOW_API_KEY= # required for production endpoints, leave blank for dev
+QUICKNODE_RPC_URL=https://your-endpoint.solana-mainnet.quiknode.pro/your-token/
+KEYPAIR_PATH=/path/to/your/keypair.json
+SERIES_TICKER=KXEPLGAME
+USDC_MINT=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v

--- a/solana/kalshi-dflow/.gitignore
+++ b/solana/kalshi-dflow/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+*.env.local
+!.env.example

--- a/solana/kalshi-dflow/README.md
+++ b/solana/kalshi-dflow/README.md
@@ -1,0 +1,79 @@
+# How to Trade Kalshi Prediction Markets on Solana Using DFlow
+
+This project contains the example code for the Quicknode guide: [How to Trade Kalshi Prediction Markets on Solana Using DFlow](https://www.quicknode.com/guides/solana-development/3rd-party-integrations/kalshi-prediction-markets-with-dflow)
+
+[DFlow](https://dflow.net) enables trading of [Kalshi's](https://kalshi.com) CFTC-regulated prediction markets on Solana. This project demonstrates how to build a TypeScript CLI that interacts with DFlow's infrastructure, covering the full trading lifecycle: buying outcome tokens, tracking positions, and redeeming winnings. The example uses English Premier League (EPL) match events as the demo market, but can be adapted to work with any Kalshi prediction market.
+
+> **Warning:** This example runs on **Solana mainnet-beta** and uses real funds. Only use a wallet loaded with the amount of SOL and USDC you are willing to spend for testing.
+
+## Prerequisites
+
+- Node.js 20+
+- A Solana wallet keypair with SOL (for transaction fees) and USDC (to purchase contracts)
+- A [Quicknode](https://www.quicknode.com) Solana mainnet RPC endpoint
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Create a `.env` file in the project root:
+   ```env
+   METADATA_API_URL=https://dev-prediction-markets-api.dflow.net
+   TRADE_API_URL=https://dev-quote-api.dflow.net
+   QUICKNODE_RPC_URL=<your-quicknode-solana-endpoint>
+   KEYPAIR_PATH=<path-to-your-wallet-keypair.json>
+   SERIES_TICKER=KXEPLGAME
+   USDC_MINT=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+   DFLOW_API_KEY= # required for production endpoints, leave blank for dev
+   ```
+
+The dev API URLs in the `.env` example work without an API key. Note that despite the `dev` in the URL, these endpoints still operate on Solana mainnet-beta and use real funds. For production, you will need a DFlow API key and must integrate [Proof](https://pond.dflow.net/build/proof/introduction) for KYC/identity verification to meet Kalshi compliance requirements.
+
+## Scripts
+
+### List market events
+Fetches active prediction market events for the configured series ticker and prints available YES/NO contracts with current ask prices.
+```bash
+npx tsx --env-file=.env src/events.ts
+```
+
+### Buy an outcome token
+Purchases YES or NO outcome tokens using USDC. Pass the outcome mint address (from the events script) and the USDC amount to spend.
+```bash
+npx tsx --env-file=.env src/buy.ts <outcome-mint-address> <usdc-amount>
+# Example: npx tsx --env-file=.env src/buy.ts <yes-mint> 1
+```
+
+### View open positions
+Scans your wallet for outcome tokens and matches them to prediction markets. Shows each position's side (YES/NO), token balance, market status, and whether it's redeemable.
+```bash
+npx tsx --env-file=.env src/positions.ts
+```
+
+### Redeem winning tokens
+Converts winning outcome tokens back to USDC after a market has settled. Pass the mint address of the winning outcome token.
+```bash
+npx tsx --env-file=.env src/redeem.ts <outcome-mint-address>
+```
+
+## Project Structure
+
+```
+src/
+├── events.ts     # Fetches and displays active market events
+├── buy.ts        # Buys YES/NO outcome tokens with USDC
+├── positions.ts  # Lists open positions in the connected wallet
+├── redeem.ts     # Redeems winning tokens for USDC post-settlement
+├── utils.ts      # Shared helpers (wallet loading, RPC calls, signing)
+└── types.ts      # TypeScript type definitions
+```
+
+## Notes
+
+- Outcome token mint addresses are printed by the events script. Copy the `YES mint` or `NO mint` value to use with the buy and redeem scripts.
+- USDC uses 6 decimal places. Pass whole dollar amounts to the buy script (e.g. `1` = $1.00 USDC). The script handles the conversion automatically.
+- The redeem script redeems your entire balance for the given mint. Losing positions cannot be redeemed. The script will print a warning if the outcome token is not a winner or if the redemption window is not yet open.
+- This project uses [`@solana/kit`](https://github.com/anza-xyz/kit) for all RPC and transaction handling.

--- a/solana/kalshi-dflow/package-lock.json
+++ b/solana/kalshi-dflow/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "kalshi-dflow-test",
+  "name": "kalshi-dflow",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "kalshi-dflow-test",
+      "name": "kalshi--dflow",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/solana/kalshi-dflow/package-lock.json
+++ b/solana/kalshi-dflow/package-lock.json
@@ -1,0 +1,1619 @@
+{
+  "name": "kalshi-dflow-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kalshi-dflow-test",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@solana/kit": "^6.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^25.3.0",
+        "tsx": "^4.21.0",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/accounts": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-6.1.0.tgz",
+      "integrity": "sha512-0jhmhSSS71ClLtBQIDrLlhkiNER4M9RIXTl1eJ1yJoFlE608JaKHTjNWsdVKdke7uBD6exdjNZkIVmouQPHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.1.0",
+        "@solana/codecs-core": "6.1.0",
+        "@solana/codecs-strings": "6.1.0",
+        "@solana/errors": "6.1.0",
+        "@solana/rpc-spec": "6.1.0",
+        "@solana/rpc-types": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/addresses": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.1.0.tgz",
+      "integrity": "sha512-QT04Vie4iICaalQQRJFMGj/P56IxXiwFtVuZHu1qjZUNmuGTOvX6G98b27RaGtLzpJ3NIku/6OtKxLUBqAKAyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.1.0",
+        "@solana/codecs-core": "6.1.0",
+        "@solana/codecs-strings": "6.1.0",
+        "@solana/errors": "6.1.0",
+        "@solana/nominal-types": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/assertions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.1.0.tgz",
+      "integrity": "sha512-pLgxB2xxTk2QfTaWpnRpSMYgaPkKYDQgptRvbwmuDQnOW1Zopg+42MT2UrDGd3UFMML1uOFPxIwKM6m51H0uXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-6.1.0.tgz",
+      "integrity": "sha512-VHBS3t8fyVjE0Nqo6b4TUnzdwdRaVo+B5ufHhPLbbjkEXzz8HB4E/OBjgasn+zWGlfScfQAiBFOsfZjbVWu4XA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.1.0",
+        "@solana/codecs-data-structures": "6.1.0",
+        "@solana/codecs-numbers": "6.1.0",
+        "@solana/codecs-strings": "6.1.0",
+        "@solana/options": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.1.0.tgz",
+      "integrity": "sha512-5rNnDOOm2GRFMJbd9imYCPNvGOrQ+TZ53NCkFFWbbB7f+L9KkLeuuAsDMFN1lCziJFlymvN785YtDnMeWj2W+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-data-structures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.1.0.tgz",
+      "integrity": "sha512-1cb9g5hrrucTuGkGxqVVq7dCwSMnn4YqwTe365iKkK8HBpLBmUl8XATf1MUs5UtDun1g9eNWOL72Psr8mIUqTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.1.0",
+        "@solana/codecs-numbers": "6.1.0",
+        "@solana/errors": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.1.0.tgz",
+      "integrity": "sha512-YPQwwl6LE3igH23ah+d8kgpyE5xFcPbuwhxCDsLWqY/ESrvO/0YQSbsgIXahbhZxN59ZC4uq1LnHhBNbpCSVQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.1.0",
+        "@solana/errors": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-strings": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.1.0.tgz",
+      "integrity": "sha512-pRH5uAn4VCFUs2rYiDITyWsRnpvs3Uh/nhSc6OSP/kusghcCcCJcUzHBIjT4x08MVacXmGUlSLe/9qPQO+QK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.1.0",
+        "@solana/codecs-numbers": "6.1.0",
+        "@solana/errors": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.1.0.tgz",
+      "integrity": "sha512-cqSwcw3Rmn85UR7PyF5nKPdlQsRYBkx7YGRvFaJ6Sal1PM+bfolhL5iT7STQoXxdhXGYwHMPg7kZYxmMdjwnJA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/fast-stable-stringify": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-6.1.0.tgz",
+      "integrity": "sha512-QXUfDFaJCFeARsxJgScWmJ153Tit7Cimk9y0UWWreNBr2Aphi67Nlcj/tr7UABTO0Qaw/0gwrK76zz3m1t3nIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/functional": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.1.0.tgz",
+      "integrity": "sha512-+Sm8ldVxSTHIKaZDvcBu81FPjknXx6OMPlakkKmXjKxPgVLl86ruqMo2yEwoDUHV7DysLrLLcRNn13rfulomRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-6.1.0.tgz",
+      "integrity": "sha512-zcsHg544t1zn7LLOVUxOWYlsKn9gvT7R+pL3cTiP2wFNoUN0h9En87H6nVqkZ8LWw23asgW0uM5uJGwfBx2h1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.1.0",
+        "@solana/instructions": "6.1.0",
+        "@solana/keys": "6.1.0",
+        "@solana/promises": "6.1.0",
+        "@solana/transaction-messages": "6.1.0",
+        "@solana/transactions": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instructions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.1.0.tgz",
+      "integrity": "sha512-w1LdbJ3yanESckNTYC5KPckgN/25FyGCm07WWrs+dCnnpRNeLiVHIytXCPmArOVAXVkOYidXzhWmqCzqKUjYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.1.0",
+        "@solana/errors": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/keys": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.1.0.tgz",
+      "integrity": "sha512-C/SGCl3VOgBQZ0mLrMxCcJYnMsGpgE8wbx29jqRY+R91m5YhS1f/GfXJPR1lN/h7QGrJ6YDm8eI0Y3AZ7goKHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.1.0",
+        "@solana/codecs-core": "6.1.0",
+        "@solana/codecs-strings": "6.1.0",
+        "@solana/errors": "6.1.0",
+        "@solana/nominal-types": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-6.1.0.tgz",
+      "integrity": "sha512-24exn11BPonquufyCkGgypVtmN4JOsdGMsbF3EZ4kFyk7ZNryCn/N8eELr1FCVrHWRXoc0xy/HFaESBULTMf6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.1.0",
+        "@solana/addresses": "6.1.0",
+        "@solana/codecs": "6.1.0",
+        "@solana/errors": "6.1.0",
+        "@solana/functional": "6.1.0",
+        "@solana/instruction-plans": "6.1.0",
+        "@solana/instructions": "6.1.0",
+        "@solana/keys": "6.1.0",
+        "@solana/offchain-messages": "6.1.0",
+        "@solana/plugin-core": "6.1.0",
+        "@solana/plugin-interfaces": "6.1.0",
+        "@solana/program-client-core": "6.1.0",
+        "@solana/programs": "6.1.0",
+        "@solana/rpc": "6.1.0",
+        "@solana/rpc-api": "6.1.0",
+        "@solana/rpc-parsed-types": "6.1.0",
+        "@solana/rpc-spec-types": "6.1.0",
+        "@solana/rpc-subscriptions": "6.1.0",
+        "@solana/rpc-types": "6.1.0",
+        "@solana/signers": "6.1.0",
+        "@solana/sysvars": "6.1.0",
+        "@solana/transaction-confirmation": "6.1.0",
+        "@solana/transaction-messages": "6.1.0",
+        "@solana/transactions": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/nominal-types": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.1.0.tgz",
+      "integrity": "sha512-+skHjN0arNNB9TLsGqA94VCx7euyGURI+qG6wck6E4D7hH6i6DxGiVrtKRghx+smJkkLtTm9BvdVKGoeNQYr7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-6.1.0.tgz",
+      "integrity": "sha512-jrUb7HGUnRA+k44upcqKeevtEdqMxYRSlFdE0JTctZunGlP3GCcTl12tFOpbnFHvBLt8RwS62+nyeES8zzNwXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.1.0",
+        "@solana/codecs-core": "6.1.0",
+        "@solana/codecs-data-structures": "6.1.0",
+        "@solana/codecs-numbers": "6.1.0",
+        "@solana/codecs-strings": "6.1.0",
+        "@solana/errors": "6.1.0",
+        "@solana/keys": "6.1.0",
+        "@solana/nominal-types": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-6.1.0.tgz",
+      "integrity": "sha512-/4FtVfR6nkHkMCumyh7/lJ6jMqyES6tKUbOJRa6gJxcIUWeRDu+XrHTHLf3gRNUqDAbFvW8FMIrQm7PdreZgRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.1.0",
+        "@solana/codecs-data-structures": "6.1.0",
+        "@solana/codecs-numbers": "6.1.0",
+        "@solana/codecs-strings": "6.1.0",
+        "@solana/errors": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-core": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-6.1.0.tgz",
+      "integrity": "sha512-2nmNCPa6B1QArqpAZHWUkK6K7UXLTrekfcfJm2V//ATEtLpKEBlv0c3mrhOYwNAKP2TpNuvEV33InXWKst9oXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-interfaces/-/plugin-interfaces-6.1.0.tgz",
+      "integrity": "sha512-eWSzfOuwtHUp8vljf5V24Tkz3WxqxiV0vD/BJZBNRZMdYRw3Cw3oeWcvEqHHxGUOie6AjIK8GrKggi8F73ZXbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.1.0",
+        "@solana/instruction-plans": "6.1.0",
+        "@solana/keys": "6.1.0",
+        "@solana/rpc-spec": "6.1.0",
+        "@solana/rpc-subscriptions-spec": "6.1.0",
+        "@solana/rpc-types": "6.1.0",
+        "@solana/signers": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/program-client-core/-/program-client-core-6.1.0.tgz",
+      "integrity": "sha512-5Apka+ulWNfLNLYNR63pLnr5XvkXTQWeaftWED93iTWTZrZv9SyFWcmIsaes6eqGXMQ3RhlebnrWODtKuAA62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.1.0",
+        "@solana/addresses": "6.1.0",
+        "@solana/codecs-core": "6.1.0",
+        "@solana/errors": "6.1.0",
+        "@solana/instruction-plans": "6.1.0",
+        "@solana/instructions": "6.1.0",
+        "@solana/plugin-interfaces": "6.1.0",
+        "@solana/rpc-api": "6.1.0",
+        "@solana/signers": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-6.1.0.tgz",
+      "integrity": "sha512-i4L4gSlIHDsdYRt3/YKVKMIN3UuYSKHRqK9B+AejcIc0y6Y/AXnHqzmpBRXEhvTXz18nt59MLXpVU4wu7ASjJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.1.0",
+        "@solana/errors": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/promises": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.1.0.tgz",
+      "integrity": "sha512-/mUW6peXQiEOaylLpGv4vtkvPzQvSbfhX9j5PNIK/ry4S3SHRQ3j3W/oGy4y3LR5alwo7NcVbubrkh4e4xwcww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-6.1.0.tgz",
+      "integrity": "sha512-R3y5PklW9mPy5Y34hsXj40R28zN2N7AGLnHqYJVkXkllwVub/QCNpSdDxAnbbS5EGOYGoUOW8s5LFoXwMSr1LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.1.0",
+        "@solana/fast-stable-stringify": "6.1.0",
+        "@solana/functional": "6.1.0",
+        "@solana/rpc-api": "6.1.0",
+        "@solana/rpc-spec": "6.1.0",
+        "@solana/rpc-spec-types": "6.1.0",
+        "@solana/rpc-transformers": "6.1.0",
+        "@solana/rpc-transport-http": "6.1.0",
+        "@solana/rpc-types": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-6.1.0.tgz",
+      "integrity": "sha512-+hO5+kZjJHuUNATUQxlJ1+ztXFkgn1j46zRwt3X7kF+VHkW3wsQ7up0JTS+Xsacmkrj1WKfymQweq8JTrsAG8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.1.0",
+        "@solana/codecs-core": "6.1.0",
+        "@solana/codecs-strings": "6.1.0",
+        "@solana/errors": "6.1.0",
+        "@solana/keys": "6.1.0",
+        "@solana/rpc-parsed-types": "6.1.0",
+        "@solana/rpc-spec": "6.1.0",
+        "@solana/rpc-transformers": "6.1.0",
+        "@solana/rpc-types": "6.1.0",
+        "@solana/transaction-messages": "6.1.0",
+        "@solana/transactions": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-parsed-types": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-6.1.0.tgz",
+      "integrity": "sha512-YKccynVgWt/gbs0tBYstNw6BSVuOeWdeAldTB2OgH95o2Q04DpO4v97X1MZDysA4SvSZM30Ek5Ni5ss3kskgdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-6.1.0.tgz",
+      "integrity": "sha512-RxpkIGizCYhXGUcap7npV2S/rAXZ7P/liozY/ExjMmCxYTDwGIW33kp/uH/JRxuzrL8+f8FqY76VsqqIe+2VZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.1.0",
+        "@solana/rpc-spec-types": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec-types": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-6.1.0.tgz",
+      "integrity": "sha512-tldMv1b6VGcvcRrY5MDWKlsyEKH6K96zE7gAIpKDX2G4T47ZOV+OMA3nh6xQpRgtyCUBsej0t80qmvTBDX/5IQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-6.1.0.tgz",
+      "integrity": "sha512-sqwj+cQinWcZ7M/9+cudKxMPTkTQyGP73980vPCWM7vCpPkp2qzgrEie4DdgDGo+NMwIjeFgu2kdUuLHI3GD/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.1.0",
+        "@solana/fast-stable-stringify": "6.1.0",
+        "@solana/functional": "6.1.0",
+        "@solana/promises": "6.1.0",
+        "@solana/rpc-spec-types": "6.1.0",
+        "@solana/rpc-subscriptions-api": "6.1.0",
+        "@solana/rpc-subscriptions-channel-websocket": "6.1.0",
+        "@solana/rpc-subscriptions-spec": "6.1.0",
+        "@solana/rpc-transformers": "6.1.0",
+        "@solana/rpc-types": "6.1.0",
+        "@solana/subscribable": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-6.1.0.tgz",
+      "integrity": "sha512-I6J+3VU0dda6EySKbDyd+1urC7RGIRPRp0DcWRVcy68NOLbq0I5C40Dn9O2Zf8iCdK4PbQ7JKdCvZ/bDd45hdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.1.0",
+        "@solana/keys": "6.1.0",
+        "@solana/rpc-subscriptions-spec": "6.1.0",
+        "@solana/rpc-transformers": "6.1.0",
+        "@solana/rpc-types": "6.1.0",
+        "@solana/transaction-messages": "6.1.0",
+        "@solana/transactions": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-6.1.0.tgz",
+      "integrity": "sha512-vsx9b+uyCr9L3giao/BTiBFA8DxV5+gDNFq0t5uL21uQ17JXzBektwzHuHoth9IjkvXV/h+IhwXfuLE9Qm4GQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.1.0",
+        "@solana/functional": "6.1.0",
+        "@solana/rpc-subscriptions-spec": "6.1.0",
+        "@solana/subscribable": "6.1.0",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-6.1.0.tgz",
+      "integrity": "sha512-P06jhqzHpZGaLeJmIQkpDeMDD1xUp53ARpmXMsduMC+U5ZKQt29CLo+JrR18boNtls6WfttjVMEbzF25/4UPVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.1.0",
+        "@solana/promises": "6.1.0",
+        "@solana/rpc-spec-types": "6.1.0",
+        "@solana/subscribable": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-6.1.0.tgz",
+      "integrity": "sha512-OsSuuRPmsmS02eR9Zz+4iTsr+21hvEMEex5vwbwN6LAGPFlQ4ohqGkxgZCwmYd+Q5HWpnn9Uuf1MDTLLrKQkig==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.1.0",
+        "@solana/functional": "6.1.0",
+        "@solana/nominal-types": "6.1.0",
+        "@solana/rpc-spec-types": "6.1.0",
+        "@solana/rpc-types": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-6.1.0.tgz",
+      "integrity": "sha512-3ebaTYuglLJagaXtjwDPVI7SQeeeFN2fpetpGKsuMAiti4fzYqEkNN8FIo+nXBzqqG/cVc2421xKjXl6sO1k/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.1.0",
+        "@solana/rpc-spec": "6.1.0",
+        "@solana/rpc-spec-types": "6.1.0",
+        "undici-types": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-types": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.1.0.tgz",
+      "integrity": "sha512-lR+Cb3v5Rpl49HsXWASy++TSE1AD86eRKabY+iuWnbBMYVGI4MamAvYwgBiygsCNc30nyO2TFNj9STMeSD/gAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.1.0",
+        "@solana/codecs-core": "6.1.0",
+        "@solana/codecs-numbers": "6.1.0",
+        "@solana/codecs-strings": "6.1.0",
+        "@solana/errors": "6.1.0",
+        "@solana/nominal-types": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-6.1.0.tgz",
+      "integrity": "sha512-WDPGZJr6jIe2dEChv/2KQBnaga8dqOjd6ceBj/HcDHxnCudo66t7GlyZ9+9jMO40AgOOb7EDE5FDqPMrHMg5Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.1.0",
+        "@solana/codecs-core": "6.1.0",
+        "@solana/errors": "6.1.0",
+        "@solana/instructions": "6.1.0",
+        "@solana/keys": "6.1.0",
+        "@solana/nominal-types": "6.1.0",
+        "@solana/offchain-messages": "6.1.0",
+        "@solana/transaction-messages": "6.1.0",
+        "@solana/transactions": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/subscribable": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-6.1.0.tgz",
+      "integrity": "sha512-HiUfkxN7638uxPmY4t0gI4+yqnFLZYJKFaT9EpWIuGrOB1d9n+uOHNs3NU7cVMwWXgfZUbztTCKyCVTbcwesNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-6.1.0.tgz",
+      "integrity": "sha512-KwJyBBrAOx0BgkiZqOKAaySDb/0JrUFSBQL9/O1kSKGy9TCRX55Ytr1HxNTcTPppWNpbM6JZVK+yW3Ruey0HRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.1.0",
+        "@solana/codecs": "6.1.0",
+        "@solana/errors": "6.1.0",
+        "@solana/rpc-types": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-6.1.0.tgz",
+      "integrity": "sha512-akSjcqAMOGPFvKctFDSzhjcRc/45WbEVdVQ9mjgH6OYo7B11WZZZaeGPlzAw5KyuG34Px941xmICkBmNqEH47Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.1.0",
+        "@solana/codecs-strings": "6.1.0",
+        "@solana/errors": "6.1.0",
+        "@solana/keys": "6.1.0",
+        "@solana/promises": "6.1.0",
+        "@solana/rpc": "6.1.0",
+        "@solana/rpc-subscriptions": "6.1.0",
+        "@solana/rpc-types": "6.1.0",
+        "@solana/transaction-messages": "6.1.0",
+        "@solana/transactions": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.1.0.tgz",
+      "integrity": "sha512-Dpv54LRVcfFbFEa/uB53LaY/TRfKuPGMKR7Z4F290zBgkj9xkpZkI+WLiJBiSloI7Qo2KZqXj3514BIeZvJLcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.1.0",
+        "@solana/codecs-core": "6.1.0",
+        "@solana/codecs-data-structures": "6.1.0",
+        "@solana/codecs-numbers": "6.1.0",
+        "@solana/errors": "6.1.0",
+        "@solana/functional": "6.1.0",
+        "@solana/instructions": "6.1.0",
+        "@solana/nominal-types": "6.1.0",
+        "@solana/rpc-types": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.1.0.tgz",
+      "integrity": "sha512-1dkiNJcTtlHm4Fvs5VohNVpv7RbvbUYYKV7lYXMPIskoLF1eZp0tVlEqD/cRl91RNz7HEysfHqBAwlcJcRmrRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.1.0",
+        "@solana/codecs-core": "6.1.0",
+        "@solana/codecs-data-structures": "6.1.0",
+        "@solana/codecs-numbers": "6.1.0",
+        "@solana/codecs-strings": "6.1.0",
+        "@solana/errors": "6.1.0",
+        "@solana/functional": "6.1.0",
+        "@solana/instructions": "6.1.0",
+        "@solana/keys": "6.1.0",
+        "@solana/nominal-types": "6.1.0",
+        "@solana/rpc-types": "6.1.0",
+        "@solana/transaction-messages": "6.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
+      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.22.0.tgz",
+      "integrity": "sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/solana/kalshi-dflow/package.json
+++ b/solana/kalshi-dflow/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "kalshi--dflow",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "events": "tsx --env-file=.env src/events.ts",
+    "buy": "tsx --env-file=.env src/buy.ts",
+    "positions": "tsx --env-file=.env src/positions.ts",
+    "redeem": "tsx --env-file=.env src/redeem.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@solana/kit": "^6.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.0",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/solana/kalshi-dflow/src/buy.ts
+++ b/solana/kalshi-dflow/src/buy.ts
@@ -1,0 +1,86 @@
+// src/buy.ts
+// Buys a Yes or No outcome token using USDC as the input
+import {
+  createSolanaRpc,
+  Signature,
+} from '@solana/kit';
+import type { OrderResponse } from './types';
+import { loadWallet, fetchJson, signAndSend, waitForOrder, requireEnv } from './utils';
+
+const TRADE_API = requireEnv('TRADE_API_URL');
+const RPC_URL   = requireEnv('QUICKNODE_RPC_URL');
+const USDC_MINT = requireEnv('USDC_MINT');
+
+const rpc = createSolanaRpc(RPC_URL);
+
+// Main
+async function buyOutcomeToken(
+  outcomeMint: string, // yesMint or noMint from market metadata
+  usdcAmount: number   // USDC to spend (e.g. 1 = $1.00)
+) {
+  const wallet = await loadWallet();
+
+  // USDC has 6 decimal places: $1.00 = 1_000_000 base units.
+  // The DFlow /order `amount` param is the INPUT quantity (USDC to spend).
+  const amountBaseUnits = usdcAmount * 1_000_000;
+
+  console.log(`\nSpending ${usdcAmount} USDC on outcome tokens`);
+  console.log(`  Input (USDC):  ${USDC_MINT}`);
+  console.log(`  Output (mint): ${outcomeMint}`);
+  console.log(`  Wallet:        ${wallet.address}\n`);
+
+  // Step 1: Request an order from DFlow Trade API
+  const params = new URLSearchParams({
+    inputMint: USDC_MINT,
+    outputMint: outcomeMint,
+    amount: String(amountBaseUnits),
+    userPublicKey: wallet.address,
+    slippageBps: 'auto',
+    dynamicComputeUnitLimit: 'true',
+    prioritizationFeeLamports: '5000',
+  });
+
+  const order = await fetchJson<OrderResponse>(`${TRADE_API}/order?${params}`);
+  console.log(`Order received — mode: ${order.executionMode}, expected out: ${order.outAmount} base units`);
+
+  // Step 2: Sign and send the transaction
+  const signature = await signAndSend(order, wallet.keyPair, rpc);
+
+  console.log(`\nTransaction submitted: ${signature}`);
+  console.log(`  Explorer: https://explorer.solana.com/tx/${signature}`);
+
+  // Step 3: For async orders, poll for fill confirmation
+  if (order.executionMode === 'async') {
+    const result = await waitForOrder(signature, order.lastValidBlockHeight, TRADE_API);
+    if (result.status === 'closed') {
+      console.log(`\n✅ Order filled! Received ${result.outAmount / 1_000_000} outcome tokens`);
+    } else if (result.status === 'expired') {
+      console.log(`\n⚠️ Order expired before being filled. No tokens received.`);
+    } else {
+      console.log(`\n⚠️ Order ended with status: ${result.status}`);
+    }
+  } else {
+    // Sync: poll signature statuses until confirmed
+    for (let i = 0; i < 30; i++) {
+      await new Promise((r) => setTimeout(r, 1_000));
+      const { value: statuses } = await rpc.getSignatureStatuses([signature as Signature]).send();
+      const s = statuses[0];
+      if (s?.confirmationStatus === 'confirmed' || s?.confirmationStatus === 'finalized') {
+        if (s.err) {
+          console.error(`\n❌ Transaction failed on-chain:`, s.err);
+        } else {
+          console.log(`\n✅ Sync order confirmed!`);
+        }
+        break;
+      }
+    }
+  }
+}
+
+const [outcomeMint, amountStr] = process.argv.slice(2);
+if (!outcomeMint || !amountStr) {
+  console.error('Usage: npm run buy -- <outcome-mint-address> <usdc-amount>');
+  process.exit(1);
+}
+
+buyOutcomeToken(outcomeMint, Number(amountStr)).catch(console.error);

--- a/solana/kalshi-dflow/src/buy.ts
+++ b/solana/kalshi-dflow/src/buy.ts
@@ -22,7 +22,7 @@ async function buyOutcomeToken(
 
   // USDC has 6 decimal places: $1.00 = 1_000_000 base units.
   // The DFlow /order `amount` param is the INPUT quantity (USDC to spend).
-  const amountBaseUnits = usdcAmount * 1_000_000;
+  const amountBaseUnits = Math.round(usdcAmount * 1_000_000);
 
   console.log(`\nSpending ${usdcAmount} USDC on outcome tokens`);
   console.log(`  Input (USDC):  ${USDC_MINT}`);

--- a/solana/kalshi-dflow/src/events.ts
+++ b/solana/kalshi-dflow/src/events.ts
@@ -1,0 +1,59 @@
+import { fetchJson, requireEnv } from './utils';
+import type { EventsResponse } from './types';
+
+const METADATA_API  = requireEnv('METADATA_API_URL');
+const SERIES_TICKER = requireEnv('SERIES_TICKER');
+const USDC_MINT     = requireEnv('USDC_MINT');
+
+// Helpers
+function toUsd(price: string | null): string {
+  if (!price) return '  N/A  ';
+  return `${Number(price).toFixed(2)}`;
+}
+
+function closeDate(ts: number): string {
+  return new Date(ts * 1000).toLocaleString(undefined, {
+    month: 'short', day: 'numeric', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+// Main
+async function listEvents() {
+  const url = `${METADATA_API}/api/v1/events?seriesTickers=${SERIES_TICKER}&status=active&withNestedMarkets=true`;
+  const { events } = await fetchJson<EventsResponse>(url);
+
+  if (events.length === 0) {
+    console.log(`No active events found for series "${SERIES_TICKER}".`);
+    return;
+  }
+
+  console.log(`\n${SERIES_TICKER} — ${events.length} active event(s)\n`);
+
+  for (const event of events) {
+    // closeTime lives on the markets, not the event itself
+    const closeTime = event.markets[0]?.closeTime;
+
+    console.log(`┌─ ${event.title}`);
+    console.log(`│  Ticker:  ${event.ticker}`);
+    if (event.subtitle) console.log(`│  Subtitle: ${event.subtitle}`);
+    if (closeTime) console.log(`│  Closes:  ${closeDate(closeTime)}`);
+    console.log('│');
+
+    for (const market of event.markets) {
+      // Prefer USDC accounts; fall back to first account available
+      const acct = market.accounts[USDC_MINT] ?? Object.values(market.accounts)[0];
+
+      console.log(`│  ▸ YES label: ${market.yesSubTitle}`);
+      console.log(`│    Ticker:   ${market.ticker}`);
+      console.log(`│    YES mint: ${acct?.yesMint ?? 'not initialized'}`);
+      console.log(`│    NO  mint: ${acct?.noMint  ?? 'not initialized'}`);
+      console.log(`│    Price (ask):  YES ${toUsd(market.yesAsk)}   NO ${toUsd(market.noAsk)}`);
+      console.log('│');
+    }
+
+    console.log('└─────────────────────────────────────────────────────\n');
+  }
+}
+
+listEvents().catch(console.error);

--- a/solana/kalshi-dflow/src/positions.ts
+++ b/solana/kalshi-dflow/src/positions.ts
@@ -55,6 +55,7 @@ async function getPositions(walletAddress: string) {
     console.log(`Market:     ${pos.market.ticker}`);
     console.log(`Title:      ${pos.market.title}`);
     console.log(`Side:       ${pos.side}`);
+    console.log(`Mint:       ${pos.mint}`);
     console.log(`Balance:    ${(Number(pos.balance) / 1_000_000).toFixed(6)} tokens`);
     console.log(`Status:     ${pos.market.status}${pos.market.result ? ` (result: ${pos.market.result})` : ''}`);
     const isOpen = acct?.redemptionStatus === 'open';

--- a/solana/kalshi-dflow/src/positions.ts
+++ b/solana/kalshi-dflow/src/positions.ts
@@ -1,0 +1,80 @@
+// src/positions.ts
+// Lists all open prediction market positions for a wallet
+import { createSolanaRpc } from '@solana/kit';
+import type { Market } from './types';
+import { loadWallet, fetchJson, parseMintAndBalance, getWalletTokenAccounts, requireEnv } from './utils';
+
+const METADATA_API = requireEnv('METADATA_API_URL');
+const RPC_URL      = requireEnv('QUICKNODE_RPC_URL');
+
+const rpc = createSolanaRpc(RPC_URL);
+
+// Main
+async function getPositions(walletAddress: string) {
+  const tokenAccounts = await getWalletTokenAccounts(rpc, walletAddress);
+  const heldMints: string[] = [];
+  const mintToBalance: Record<string, bigint> = {};
+
+  for (const { account } of tokenAccounts) {
+    const { mint, amount } = parseMintAndBalance(account.data as [string, string]);
+    if (amount > 0n) {
+      heldMints.push(mint);
+      mintToBalance[mint] = amount;
+    }
+  }
+
+  if (heldMints.length === 0) {
+    console.log('No SPL tokens found in wallet.');
+    return;
+  }
+
+  console.log(`\nChecking ${heldMints.length} token(s) for prediction market positions...\n`);
+
+  const positions: { mint: string; side: 'YES' | 'NO'; market: Market; balance: bigint }[] = [];
+
+  // For each held mint, check if it is an outcome token via DFlow Metadata API
+  for (const mint of heldMints) {
+    let market: Market;
+    try {
+      market = await fetchJson<Market>(`${METADATA_API}/api/v1/market/by-mint/${mint}`);
+    } catch { continue; }
+    const allAccts = Object.values(market.accounts);
+    const side = allAccts.some(a => a.yesMint === String(mint)) ? 'YES' : 'NO';
+    positions.push({ mint, side, market, balance: mintToBalance[mint]! });
+  }
+
+  if (positions.length === 0) {
+    console.log('No prediction market positions found.');
+    return;
+  }
+
+  console.log(`Found ${positions.length} open position(s):\n`);
+
+  for (const pos of positions) {
+    const acct = Object.values(pos.market.accounts)[0];
+    console.log(`Market:     ${pos.market.ticker}`);
+    console.log(`Title:      ${pos.market.title}`);
+    console.log(`Side:       ${pos.side}`);
+    console.log(`Balance:    ${(Number(pos.balance) / 1_000_000).toFixed(6)} tokens`);
+    console.log(`Status:     ${pos.market.status}${pos.market.result ? ` (result: ${pos.market.result})` : ''}`);
+    const isOpen = acct?.redemptionStatus === 'open';
+    const sideWon =
+      (pos.side === 'YES' && pos.market.result === 'yes') ||
+      (pos.side === 'NO'  && pos.market.result === 'no');
+    const isScalar = !pos.market.result && acct?.scalarOutcomePercent != null;
+    const redeemable = isOpen && (sideWon || isScalar);
+    const redeemLabel = redeemable
+      ? '✅ Yes'
+      : !pos.market.result
+        ? '⏳ Pending (not yet determined)'
+        : sideWon
+          ? '⏳ Won — redemption not open yet'
+          : '❌ Lost';
+    console.log(`Redeemable: ${redeemLabel}`);
+    console.log();
+  }
+}
+
+loadWallet()
+  .then(({ address: walletAddress }) => getPositions(walletAddress))
+  .catch(console.error);

--- a/solana/kalshi-dflow/src/redeem.ts
+++ b/solana/kalshi-dflow/src/redeem.ts
@@ -24,6 +24,7 @@ async function redeemOutcomeTokens(outcomeMint: string) {
     process.exit(1);
   }
   const tokenAmount = Number(rawBalance);
+  const displayAmount = tokenAmount / 1_000_000;
 
   // Step 1: Verify the token is redeemable
   const market = await fetchJson<Market>(`${METADATA_API}/api/v1/market/by-mint/${outcomeMint}`);
@@ -50,7 +51,7 @@ async function redeemOutcomeTokens(outcomeMint: string) {
     return;
   }
 
-  console.log(`\nRedeeming ${tokenAmount} tokens from market: ${market.ticker}`);
+  console.log(`\nRedeeming ${displayAmount} tokens from market: ${market.ticker}`);
 
   if (isScalar && acct.scalarOutcomePercent !== null) {
     const yesPct = (acct.scalarOutcomePercent / 100).toFixed(2);

--- a/solana/kalshi-dflow/src/redeem.ts
+++ b/solana/kalshi-dflow/src/redeem.ts
@@ -27,12 +27,14 @@ async function redeemOutcomeTokens(outcomeMint: string) {
 
   // Step 1: Verify the token is redeemable
   const market = await fetchJson<Market>(`${METADATA_API}/api/v1/market/by-mint/${outcomeMint}`);
-  const acct = Object.values(market.accounts)[0];
+  const allAccts = Object.values(market.accounts);
+  const acct = allAccts.find(a => a.yesMint === outcomeMint || a.noMint === outcomeMint)
+            ?? allAccts[0];
   if (!acct) throw new Error('No account info found for this market.');
 
   const isWinningMint =
-    (market.result === 'yes' && acct.yesMint === outcomeMint) ||
-    (market.result === 'no' && acct.noMint === outcomeMint);
+    (market.result === 'yes' && allAccts.some(a => a.yesMint === outcomeMint)) ||
+    (market.result === 'no'  && allAccts.some(a => a.noMint  === outcomeMint));
   const isScalar = !market.result && acct.scalarOutcomePercent !== null;
 
   if (!isWinningMint && !isScalar) {

--- a/solana/kalshi-dflow/src/redeem.ts
+++ b/solana/kalshi-dflow/src/redeem.ts
@@ -1,0 +1,90 @@
+import { createSolanaRpc } from '@solana/kit';
+import type { Market, OrderResponse } from './types';
+import { loadWallet, fetchJson, signAndSend, waitForOrder, parseMintAndBalance, getWalletTokenAccounts, requireEnv } from './utils';
+
+const METADATA_API = requireEnv('METADATA_API_URL');
+const TRADE_API    = requireEnv('TRADE_API_URL');
+const RPC_URL      = requireEnv('QUICKNODE_RPC_URL');
+const USDC_MINT    = requireEnv('USDC_MINT');
+
+const rpc = createSolanaRpc(RPC_URL);
+
+// Main
+async function redeemOutcomeTokens(outcomeMint: string) {
+  const wallet = await loadWallet();
+
+  const tokenAccounts = await getWalletTokenAccounts(rpc, wallet.address);
+  let rawBalance = 0n;
+  for (const { account } of tokenAccounts) {
+    const { mint, amount } = parseMintAndBalance(account.data as [string, string]);
+    if (mint === outcomeMint) { rawBalance = amount; break; }
+  }
+  if (rawBalance === 0n) {
+    console.error('No balance found for this mint in your wallet.');
+    process.exit(1);
+  }
+  const tokenAmount = Number(rawBalance);
+
+  // Step 1: Verify the token is redeemable
+  const market = await fetchJson<Market>(`${METADATA_API}/api/v1/market/by-mint/${outcomeMint}`);
+  const acct = Object.values(market.accounts)[0];
+  if (!acct) throw new Error('No account info found for this market.');
+
+  const isWinningMint =
+    (market.result === 'yes' && acct.yesMint === outcomeMint) ||
+    (market.result === 'no' && acct.noMint === outcomeMint);
+  const isScalar = !market.result && acct.scalarOutcomePercent !== null;
+
+  if (!isWinningMint && !isScalar) {
+    console.log(`\n⚠️ This outcome token cannot be redeemed.`);
+    console.log(`  Market result: ${market.result ?? 'not yet determined'}`);
+    console.log(`  Market status: ${market.status}`);
+    return;
+  }
+
+  if (acct.redemptionStatus !== 'open') {
+    console.log(`\n⚠️ Redemption window is not open yet.`);
+    console.log(`  redemptionStatus: ${acct.redemptionStatus}`);
+    return;
+  }
+
+  console.log(`\nRedeeming ${tokenAmount} tokens from market: ${market.ticker}`);
+
+  if (isScalar && acct.scalarOutcomePercent !== null) {
+    const yesPct = (acct.scalarOutcomePercent / 100).toFixed(2);
+    const noPct = ((10_000 - acct.scalarOutcomePercent) / 100).toFixed(2);
+    console.log(`  Scalar market — YES payout: ${yesPct}%  NO payout: ${noPct}%`);
+  }
+
+  // Step 2: Request a redemption order (same /order endpoint as buying)
+  const params = new URLSearchParams({
+    inputMint: outcomeMint,
+    outputMint: USDC_MINT,
+    amount: String(tokenAmount),
+    userPublicKey: wallet.address,
+  });
+
+  const order = await fetchJson<OrderResponse>(`${TRADE_API}/order?${params}`);
+
+  // Step 3: Sign and send
+  const signature = await signAndSend(order, wallet.keyPair, rpc);
+
+  console.log(`\nTransaction submitted: ${signature}`);
+  console.log(`  Explorer: https://explorer.solana.com/tx/${signature}`);
+
+  // Step 4: Monitor until closed
+  const result = await waitForOrder(signature, order.lastValidBlockHeight, TRADE_API);
+  if (result.status === 'closed') {
+    console.log(`\n✅ Redemption complete! Received ${result.outAmount / 1_000_000} USDC`);
+  } else {
+    console.log(`\n⚠️ Redemption ended with status: ${result.status}`);
+  }
+}
+
+const [mint] = process.argv.slice(2);
+if (!mint) {
+  console.error('Usage: npm run redeem -- <outcome-mint-address>');
+  process.exit(1);
+}
+
+redeemOutcomeTokens(mint).catch(console.error);

--- a/solana/kalshi-dflow/src/redeem.ts
+++ b/solana/kalshi-dflow/src/redeem.ts
@@ -1,4 +1,4 @@
-import { createSolanaRpc } from '@solana/kit';
+import { createSolanaRpc, Signature } from '@solana/kit';
 import type { Market, OrderResponse } from './types';
 import { loadWallet, fetchJson, signAndSend, waitForOrder, parseMintAndBalance, getWalletTokenAccounts, requireEnv } from './utils';
 
@@ -74,12 +74,29 @@ async function redeemOutcomeTokens(outcomeMint: string) {
   console.log(`\nTransaction submitted: ${signature}`);
   console.log(`  Explorer: https://explorer.solana.com/tx/${signature}`);
 
-  // Step 4: Monitor until closed
-  const result = await waitForOrder(signature, order.lastValidBlockHeight, TRADE_API);
-  if (result.status === 'closed') {
-    console.log(`\n✅ Redemption complete! Received ${result.outAmount / 1_000_000} USDC`);
+  // Step 4: Monitor until settled
+  if (order.executionMode === 'async') {
+    const result = await waitForOrder(signature, order.lastValidBlockHeight, TRADE_API);
+    if (result.status === 'closed') {
+      console.log(`\n✅ Redemption complete! Received ${result.outAmount / 1_000_000} USDC`);
+    } else {
+      console.log(`\n⚠️ Redemption ended with status: ${result.status}`);
+    }
   } else {
-    console.log(`\n⚠️ Redemption ended with status: ${result.status}`);
+    // Sync: poll signature statuses until confirmed
+    for (let i = 0; i < 30; i++) {
+      await new Promise((r) => setTimeout(r, 1_000));
+      const { value: statuses } = await rpc.getSignatureStatuses([signature as Signature]).send();
+      const s = statuses[0];
+      if (s?.confirmationStatus === 'confirmed' || s?.confirmationStatus === 'finalized') {
+        if (s.err) {
+          console.error(`\n❌ Transaction failed on-chain:`, s.err);
+        } else {
+          console.log(`\n✅ Redemption confirmed!`);
+        }
+        break;
+      }
+    }
   }
 }
 

--- a/solana/kalshi-dflow/src/types.ts
+++ b/solana/kalshi-dflow/src/types.ts
@@ -1,0 +1,47 @@
+export interface MarketAccountInfo {
+  yesMint: string;
+  noMint: string;
+  isInitialized?: boolean;
+  redemptionStatus: string;
+  scalarOutcomePercent: number | null;
+}
+
+export interface Market {
+  ticker: string;
+  title: string;
+  yesSubTitle?: string;
+  closeTime?: number | null;
+  status?: string;
+  result?: string | null;
+  yesBid: string | null;
+  yesAsk: string | null;
+  noBid: string | null;
+  noAsk: string | null;
+  accounts: Record<string, MarketAccountInfo>;
+}
+
+export interface Event {
+  ticker: string;
+  title: string;
+  subtitle: string | null;
+  markets: Market[];
+}
+
+export interface EventsResponse {
+  events: Event[];
+  cursor: number | null;
+}
+
+export interface OrderResponse {
+  outAmount: string;
+  executionMode: 'sync' | 'async';
+  transaction: string;
+  lastValidBlockHeight: number;
+  revertMint?: string;
+}
+
+export interface OrderStatusResponse {
+  status: 'pending' | 'expired' | 'failed' | 'open' | 'pendingClose' | 'closed';
+  outAmount: number;
+  reverts?: { signature: string }[];
+}

--- a/solana/kalshi-dflow/src/utils.ts
+++ b/solana/kalshi-dflow/src/utils.ts
@@ -1,0 +1,95 @@
+import {
+  createKeyPairFromBytes,
+  getAddressFromPublicKey,
+  getAddressDecoder,
+  address,
+  sendTransactionWithoutConfirmingFactory,
+  assertIsTransactionWithinSizeLimit,
+  getTransactionDecoder,
+  signTransaction,
+  getSignatureFromTransaction,
+} from '@solana/kit';
+import type { createSolanaRpc } from '@solana/kit';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import type { OrderResponse, OrderStatusResponse } from './types';
+
+type SolanaRpc = ReturnType<typeof createSolanaRpc>;
+
+export function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing env: ${name}`);
+  return value;
+}
+
+export function getHeaders(): Record<string, string> {
+  const h: Record<string, string> = { 'Content-Type': 'application/json' };
+  const apiKey = process.env.DFLOW_API_KEY;
+  if (apiKey) h['x-api-key'] = apiKey;
+  return h;
+}
+
+export async function loadWallet() {
+  const keypairPath = process.env.KEYPAIR_PATH || path.join(os.homedir(), '.config', 'solana', 'id.json');
+  const secretKey = Uint8Array.from(JSON.parse(fs.readFileSync(keypairPath, 'utf-8')));
+  const keyPair = await createKeyPairFromBytes(secretKey);
+  const address = await getAddressFromPublicKey(keyPair.publicKey);
+  return { keyPair, address };
+}
+
+export async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, { headers: getHeaders(), ...options });
+  if (!res.ok) throw new Error(`API error ${res.status}: ${await res.text()}`);
+  return res.json() as Promise<T>;
+}
+
+export async function signAndSend(
+  order: OrderResponse,
+  keyPair: Awaited<ReturnType<typeof createKeyPairFromBytes>>,
+  rpc: SolanaRpc,
+): Promise<string> {
+  const txBytes = Buffer.from(order.transaction, 'base64');
+  const transaction = getTransactionDecoder().decode(txBytes);
+  const signedTx = await signTransaction([keyPair], transaction);
+  const signature = getSignatureFromTransaction(signedTx);
+  assertIsTransactionWithinSizeLimit(signedTx);
+  const sendTx = sendTransactionWithoutConfirmingFactory({ rpc });
+  await sendTx(signedTx, { commitment: 'confirmed', skipPreflight: false });
+  return signature as string;
+}
+
+export async function waitForOrder(
+  sig: string,
+  lastValidBlockHeight: number,
+  tradeApiUrl: string,
+): Promise<OrderStatusResponse> {
+  while (true) {
+    const status = await fetchJson<OrderStatusResponse>(
+      `${tradeApiUrl}/order-status?signature=${sig}&lastValidBlockHeight=${lastValidBlockHeight}`
+    );
+    console.log(`  Status: ${status.status}`);
+    if (['closed', 'expired', 'failed'].includes(status.status)) return status;
+    await new Promise((r) => setTimeout(r, 2_000)); // Wait before next poll to avoid rate-limiting
+  }
+}
+
+export function parseMintAndBalance(accountData: [string, string]): { mint: string; amount: bigint } {
+  const [base64Data] = accountData;
+  const data = Buffer.from(base64Data, 'base64');
+  const mint = getAddressDecoder().decode(data.subarray(0, 32));
+  const amount = data.readBigUInt64LE(64);
+  return { mint, amount };
+}
+
+// SPL Token programs
+export const TOKEN_PROGRAM      = address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+export const TOKEN_2022_PROGRAM = address('TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb');
+
+export async function getWalletTokenAccounts(rpc: SolanaRpc, walletAddress: string) {
+  const [{ value: legacyAccounts }, { value: token2022Accounts }] = await Promise.all([
+    rpc.getTokenAccountsByOwner(address(walletAddress), { programId: TOKEN_PROGRAM },      { encoding: 'base64' }).send(),
+    rpc.getTokenAccountsByOwner(address(walletAddress), { programId: TOKEN_2022_PROGRAM }, { encoding: 'base64' }).send(),
+  ]);
+  return [...legacyAccounts, ...token2022Accounts];
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new CLI scripts that sign and submit Solana mainnet transactions and interact with external DFlow APIs, so misconfiguration or API/tx handling issues could lead to unintended real-fund trades.
> 
> **Overview**
> Adds a new `solana/kalshi-dflow` example project demonstrating end-to-end trading of Kalshi prediction markets on Solana via DFlow.
> 
> Includes CLI scripts to **list active events/markets**, **buy YES/NO outcome tokens with USDC**, **scan a wallet for open positions**, and **redeem winning/scalar outcome tokens back to USDC**, with shared utilities for env handling, wallet loading, transaction signing/sending, and order-status polling. Adds project scaffolding (`package.json`/lockfile), `.env.example`, `.gitignore`, and a README with setup and safety warnings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3aefaefac2ec411c576e06f954cc8898cd71883f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->