### PR TITLE
Remove dropped builder_labels table from SQL explorer query

### DIFF
--- a/sample-dapps/sql-explorer-cookbook/src/data/queries.ts
+++ b/sample-dapps/sql-explorer-cookbook/src/data/queries.ts
@@ -981,20 +981,18 @@ LIMIT 50`,
     description: "Builder (frontend) transaction volume and fees",
     category: "Builders",
     sql: `SELECT
-  b.builder,
-  l.builder_name,
+  builder,
   count() AS tx_count,
-  sum(toFloat64(b.builder_fee)) AS total_fees,
-  uniqExact(b.user) AS unique_users
-FROM hyperliquid_builder_transactions b
-LEFT JOIN hyperliquid_builder_labels l ON b.builder = l.builder_address
-WHERE b.block_time > now() - INTERVAL 24 HOUR
-GROUP BY b.builder, l.builder_name
+  sum(toFloat64(builder_fee)) AS total_fees,
+  uniqExact(user) AS unique_users
+FROM hyperliquid_builder_transactions
+WHERE block_time > now() - INTERVAL 24 HOUR
+GROUP BY builder
 ORDER BY total_fees DESC
 LIMIT 50`,
     chartConfig: {
       type: "bar",
-      xKey: "builder_name",
+      xKey: "builder",
       yKeys: ["total_fees", "unique_users"],
       xLabel: "Builder",
       yLabel: "Total Fees",


### PR DESCRIPTION
## Summary
- Removes `LEFT JOIN hyperliquid_builder_labels` from the "Builder activity (24h)" pre-built query, since the table was dropped in the schema update (quiknode-labs/docs#2951)
- All other 40 queries audited — no changes needed (column reordering, type wrappers, and new columns are non-breaking)

## Test plan
- [ ] Verify the builder-activity-24h query runs without errors against the updated schema

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates a single prebuilt SQL query and its chart mapping to match a dropped table; main risk is altered output columns (no `builder_name`) affecting downstream display.
> 
> **Overview**
> Updates the prebuilt `builder-activity-24h` query to stop joining `hyperliquid_builder_labels` (dropped from the schema) and instead aggregate directly by `builder` from `hyperliquid_builder_transactions`.
> 
> Adjusts the chart configuration to use `builder` as the x-axis key, since the query no longer returns `builder_name`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90791f6fe5bf192e9f018f6077a24ddb4e52115a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->