### PR TITLE
Add SQL Explorer sample app: Hyperliquid Intelligence Bot

### DIFF
--- a/sql-explorer/hyperliquid-intel-bot/.env.example
+++ b/sql-explorer/hyperliquid-intel-bot/.env.example
@@ -1,0 +1,3 @@
+QUICKNODE_API_KEY=your_quicknode_api_key
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token
+TELEGRAM_CHAT_ID=your_telegram_chat_id

--- a/sql-explorer/hyperliquid-intel-bot/.gitignore
+++ b/sql-explorer/hyperliquid-intel-bot/.gitignore
@@ -1,0 +1,6 @@
+.env
+.venv/
+__pycache__/
+*.pyc
+node_modules/
+dist/

--- a/sql-explorer/hyperliquid-intel-bot/README.md
+++ b/sql-explorer/hyperliquid-intel-bot/README.md
@@ -32,7 +32,7 @@ cp .env.example .env
 ```bash
 git clone https://github.com/quiknode-labs/qn-guide-examples.git
 cd qn-guide-examples/sql-explorer/hyperliquid-intel-bot/typescript
-npm install
+pnpm install
 cp .env.example .env
 ```
 
@@ -73,8 +73,8 @@ python3 bot.py --dry-run    # print digest to console only
 ### TypeScript
 
 ```bash
-npm start                  # send digest to Telegram
-npm run dry-run            # print digest to console only
+pnpm start                  # send digest to Telegram
+pnpm run dry-run            # print digest to console only
 ```
 
 ## Notes

--- a/sql-explorer/hyperliquid-intel-bot/README.md
+++ b/sql-explorer/hyperliquid-intel-bot/README.md
@@ -22,7 +22,7 @@
 ```bash
 git clone https://github.com/quiknode-labs/qn-guide-examples.git
 cd qn-guide-examples/sql-explorer/hyperliquid-intel-bot
-python -m venv .venv && source .venv/bin/activate
+python3 -m venv .venv && source .venv/bin/activate  # use "python" if python3 is not found on your system
 pip install -r requirements.txt
 cp .env.example .env
 ```
@@ -52,24 +52,22 @@ Open `.env` and fill in the three required values:
 2. Start a chat and send `/newbot`. Follow the prompts to set a name and username.
 3. BotFather will reply with a **Bot Token**. Save it for your `.env` file.
 
-#### Creating a Channel
+#### Getting the Chat ID
 
-1. In Telegram, create a new channel (public or private).
-2. For a **public** channel, give it a username (e.g., `@hyperliquid_digest`). Use this username as your `TELEGRAM_CHAT_ID`.
-3. For a **private** channel, forward a message from the channel to a bot like `@JsonDumpCUBot` and look for the `forward_from_chat.id` value. Use that numeric ID as your `TELEGRAM_CHAT_ID`.
+`TELEGRAM_CHAT_ID` must be a **numeric ID** (e.g. `-1001234567890`). Usernames do not work.
 
-#### Adding the Bot to the Channel
-
-1. Open your channel's settings.
-2. Add your bot as an administrator so it can post messages.
+1. Add your bot to the channel or group as an administrator, or send it a direct message.
+2. Send any message to the bot.
+3. Open `https://api.telegram.org/bot<YOUR_TOKEN>/getUpdates` in your browser.
+4. Find `"chat": {"id": ...}` in the response. That number is your `TELEGRAM_CHAT_ID`.
 
 ## Run
 
 ### Python
 
 ```bash
-python bot.py              # send digest to Telegram
-python bot.py --dry-run    # print digest to console only
+python3 bot.py              # send digest to Telegram
+python3 bot.py --dry-run    # print digest to console only
 ```
 
 ### TypeScript

--- a/sql-explorer/hyperliquid-intel-bot/README.md
+++ b/sql-explorer/hyperliquid-intel-bot/README.md
@@ -1,0 +1,92 @@
+# Hyperliquid Intelligence Bot
+
+> A scheduled bot that queries Quicknode SQL Explorer for Hyperliquid market data and delivers a daily digest to Telegram. Built as part of the [Build a Hyperliquid Intelligence Bot with SQL Explorer](https://www.quicknode.com/guides/quicknode-products/sql-explorer/build-a-hyperliquid-intelligence-bot) guide.
+
+## Features
+
+- Queries four Hyperliquid tables via the SQL Explorer REST API: platform metrics, top assets by volume, liquidations, and funding rate extremes
+- Composes a formatted daily market digest
+- Sends the digest to a Telegram channel
+- Supports `--dry-run` mode for testing without Telegram
+
+## Prerequisites
+
+- Python 3.10+ (or Node.js 20+ for TypeScript)
+- A [Quicknode account](https://quicknode.com) with an API key that has SQL Explorer access
+- A Telegram bot token and chat ID
+
+## Setup
+
+### Python
+
+```bash
+git clone https://github.com/quiknode-labs/qn-guide-examples.git
+cd qn-guide-examples/sql-explorer/hyperliquid-intel-bot
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+```
+
+### TypeScript
+
+```bash
+git clone https://github.com/quiknode-labs/qn-guide-examples.git
+cd qn-guide-examples/sql-explorer/hyperliquid-intel-bot/typescript
+npm install
+cp .env.example .env
+```
+
+### Environment Variables
+
+Open `.env` and fill in the three required values:
+
+| Variable | Description |
+|----------|-------------|
+| `QUICKNODE_API_KEY` | Your Quicknode API key with SQL Explorer access. Find it under **API Keys** in the [Quicknode Dashboard](https://dashboard.quicknode.com). |
+| `TELEGRAM_BOT_TOKEN` | The token for your Telegram bot (see below). |
+| `TELEGRAM_CHAT_ID` | The channel or group ID where the bot will post (see below). |
+
+#### Creating a Telegram Bot
+
+1. Open Telegram and search for **BotFather**.
+2. Start a chat and send `/newbot`. Follow the prompts to set a name and username.
+3. BotFather will reply with a **Bot Token**. Save it for your `.env` file.
+
+#### Creating a Channel
+
+1. In Telegram, create a new channel (public or private).
+2. For a **public** channel, give it a username (e.g., `@hyperliquid_digest`). Use this username as your `TELEGRAM_CHAT_ID`.
+3. For a **private** channel, forward a message from the channel to a bot like `@JsonDumpCUBot` and look for the `forward_from_chat.id` value. Use that numeric ID as your `TELEGRAM_CHAT_ID`.
+
+#### Adding the Bot to the Channel
+
+1. Open your channel's settings.
+2. Add your bot as an administrator so it can post messages.
+
+## Run
+
+### Python
+
+```bash
+python bot.py              # send digest to Telegram
+python bot.py --dry-run    # print digest to console only
+```
+
+### TypeScript
+
+```bash
+npm start                  # send digest to Telegram
+npm run dry-run            # print digest to console only
+```
+
+## Notes
+
+- **Python files** live at the project root: `bot.py`, `queries.py`, `formatter.py`
+- **TypeScript files** live in `typescript/src/`: `bot.ts`, `queries.ts`, `formatter.ts`
+- All SQL queries are identical across both implementations
+- The bot is stateless, so you can schedule it with cron, systemd timers, or a cloud scheduler
+- Modify the SQL in `queries.py` / `queries.ts` to customize the digest sections
+
+## Support & Feedback
+
+- Repo issues: please open a GitHub issue for bugs/requests related to this example.

--- a/sql-explorer/hyperliquid-intel-bot/bot.py
+++ b/sql-explorer/hyperliquid-intel-bot/bot.py
@@ -27,12 +27,16 @@ from queries import (
 
 load_dotenv()
 
-TELEGRAM_BOT_TOKEN = os.environ["TELEGRAM_BOT_TOKEN"]
-TELEGRAM_CHAT_ID = os.environ["TELEGRAM_CHAT_ID"]
+TELEGRAM_BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN")
+TELEGRAM_CHAT_ID = os.environ.get("TELEGRAM_CHAT_ID")
 
 
 def send_telegram(message: str) -> None:
     """Send a message to the configured Telegram chat."""
+    if not TELEGRAM_BOT_TOKEN or not TELEGRAM_CHAT_ID:
+        raise ValueError(
+            "TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID must be set to send messages."
+        )
     url = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage"
     resp = requests.post(
         url,

--- a/sql-explorer/hyperliquid-intel-bot/bot.py
+++ b/sql-explorer/hyperliquid-intel-bot/bot.py
@@ -1,0 +1,76 @@
+"""
+Hyperliquid Intelligence Bot
+
+Queries Quicknode SQL Explorer for Hyperliquid market data, composes a
+formatted digest, and sends it to a Telegram channel.
+
+Usage:
+    python bot.py              # run once, send digest immediately
+    python bot.py --dry-run    # print digest to console without sending
+
+Guide: https://www.quicknode.com/guides/quicknode-products/sql-explorer/build-a-hyperliquid-intelligence-bot
+"""
+
+import os
+import sys
+
+import requests
+from dotenv import load_dotenv
+
+from formatter import format_digest
+from queries import (
+    get_funding_extremes,
+    get_liquidations,
+    get_platform_overview,
+    get_top_assets,
+)
+
+load_dotenv()
+
+TELEGRAM_BOT_TOKEN = os.environ["TELEGRAM_BOT_TOKEN"]
+TELEGRAM_CHAT_ID = os.environ["TELEGRAM_CHAT_ID"]
+
+
+def send_telegram(message: str) -> None:
+    """Send a message to the configured Telegram chat."""
+    url = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage"
+    resp = requests.post(
+        url,
+        json={
+            "chat_id": TELEGRAM_CHAT_ID,
+            "text": message,
+            "parse_mode": "Markdown",
+        },
+    )
+    resp.raise_for_status()
+    print(f"Digest sent (chat_id={TELEGRAM_CHAT_ID})")
+
+
+def main() -> None:
+    dry_run = "--dry-run" in sys.argv
+
+    print("Fetching digest data from SQL Explorer...")
+
+    print("Platform overview:", end="")
+    overview = get_platform_overview()
+
+    print("Top assets:", end="")
+    assets = get_top_assets()
+
+    print("Liquidations:", end="")
+    liquidations = get_liquidations()
+
+    print("Funding extremes:", end="")
+    funding = get_funding_extremes()
+
+    digest = format_digest(overview, assets, liquidations, funding)
+    print(f"\n{digest}")
+
+    if dry_run:
+        print("\n[dry-run] Skipping Telegram send.")
+    else:
+        send_telegram(digest)
+
+
+if __name__ == "__main__":
+    main()

--- a/sql-explorer/hyperliquid-intel-bot/formatter.py
+++ b/sql-explorer/hyperliquid-intel-bot/formatter.py
@@ -1,0 +1,96 @@
+"""
+Digest formatting for Telegram delivery.
+
+Takes raw query result dictionaries and composes a Markdown-formatted
+message suitable for Telegram's "Markdown" parse mode.
+"""
+
+from datetime import datetime, timezone
+
+
+def format_number(n: float, prefix: str = "$") -> str:
+    """Format large numbers with K/M/B suffixes."""
+    abs_n = abs(n)
+    sign = "-" if n < 0 else ""
+    if abs_n >= 1_000_000_000:
+        return f"{sign}{prefix}{abs_n / 1_000_000_000:.1f}B"
+    if abs_n >= 1_000_000:
+        return f"{sign}{prefix}{abs_n / 1_000_000:.1f}M"
+    if abs_n >= 1_000:
+        return f"{sign}{prefix}{abs_n / 1_000:.1f}K"
+    return f"{sign}{prefix}{abs_n:,.2f}"
+
+
+def format_digest(
+    overview: list[dict],
+    assets: list[dict],
+    liquidations: list[dict],
+    funding: list[dict],
+) -> str:
+    """Compose all query results into a Telegram-ready digest."""
+    now = datetime.now(timezone.utc).strftime("%B %d, %Y")
+    lines: list[str] = []
+
+    lines.append(f"*Hyperliquid Daily Digest*")
+    lines.append(f"_{now}_")
+    lines.append("")
+
+    # --- Platform overview (aggregate the week) ---
+    if overview:
+        total_vol = sum(float(r["total_volume_usd"]) for r in overview)
+        total_fills = sum(int(r["total_fills"]) for r in overview)
+        peak_traders = max(int(r["active_traders"]) for r in overview)
+        total_fees = sum(float(r["total_fees"]) for r in overview)
+        total_liq_vol = sum(float(r["liquidation_volume_usd"]) for r in overview)
+
+        lines.append("*Overview (7d)*")
+        lines.append(f"Volume: {format_number(total_vol)}")
+        lines.append(f"Fills: {format_number(total_fills, prefix='')}")
+        lines.append(f"Active traders: {peak_traders:,}")
+        lines.append(f"Fees: {format_number(total_fees)}")
+        lines.append(f"Liquidation volume: {format_number(total_liq_vol)}")
+        lines.append("")
+
+    # --- Top assets by volume ---
+    if assets:
+        lines.append("*Top Assets by Volume (24h)*")
+        for i, row in enumerate(assets[:5], 1):
+            vol = format_number(float(row["volume_usd"]))
+            lines.append(f"{i}. {row['coin']}  {vol}")
+        lines.append("")
+
+    # --- Liquidations ---
+    if liquidations:
+        total_liq = sum(float(r["liq_volume_usd"]) for r in liquidations)
+        total_users = sum(int(r["users_rekt"]) for r in liquidations)
+
+        lines.append("*Liquidations (24h)*")
+        lines.append(f"Total: {format_number(total_liq)}")
+        lines.append(f"Unique addresses: {total_users:,}")
+
+        # Top 3 coins by liquidation volume
+        for row in liquidations[:3]:
+            vol = format_number(float(row["liq_volume_usd"]))
+            lines.append(f"  {row['coin']}: {vol} ({row['users_rekt']} users)")
+        lines.append("")
+
+    # --- Funding rate extremes ---
+    if funding:
+        sorted_funding = sorted(
+            funding, key=lambda r: float(r["annualized_rate_pct"])
+        )
+        most_neg = sorted_funding[0]
+        most_pos = sorted_funding[-1]
+
+        lines.append("*Funding Rate Extremes*")
+        # Show top 5 by absolute value (already sorted that way from the query)
+        for row in funding[:5]:
+            rate = float(row["annualized_rate_pct"])
+            sign = "+" if rate > 0 else ""
+            oi = format_number(float(row["oi_usd"]))
+            lines.append(f"{row['coin']}: {sign}{rate}% ann.  OI {oi}")
+        lines.append("")
+
+    lines.append("_Powered by Quicknode SQL Explorer_")
+
+    return "\n".join(lines)

--- a/sql-explorer/hyperliquid-intel-bot/formatter.py
+++ b/sql-explorer/hyperliquid-intel-bot/formatter.py
@@ -66,7 +66,7 @@ def format_digest(
 
         lines.append("*Liquidations (24h)*")
         lines.append(f"Total: {format_number(total_liq)}")
-        lines.append(f"Unique addresses: {total_users:,}")
+        lines.append(f"Addresses liquidated: {total_users:,}")
 
         # Top 3 coins by liquidation volume
         for row in liquidations[:3]:

--- a/sql-explorer/hyperliquid-intel-bot/queries.py
+++ b/sql-explorer/hyperliquid-intel-bot/queries.py
@@ -13,7 +13,9 @@ from dotenv import load_dotenv
 load_dotenv()
 
 SQL_EXPLORER_URL = "https://api.quicknode.com/sql/rest/v1/query"
-QUICKNODE_API_KEY = os.environ["QUICKNODE_API_KEY"]
+QUICKNODE_API_KEY = os.environ.get("QUICKNODE_API_KEY")
+if not QUICKNODE_API_KEY:
+    raise ValueError("Set QUICKNODE_API_KEY in your .env file before running the bot.")
 CLUSTER_ID = "hyperliquid-core-mainnet"
 
 

--- a/sql-explorer/hyperliquid-intel-bot/queries.py
+++ b/sql-explorer/hyperliquid-intel-bot/queries.py
@@ -1,0 +1,111 @@
+"""
+SQL Explorer query definitions and REST API client.
+
+Each function wraps a SQL query and sends it to the Quicknode SQL Explorer
+REST API. The SQL is standard ClickHouse-compatible syntax.
+"""
+
+import os
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+SQL_EXPLORER_URL = "https://api.quicknode.com/sql/rest/v1/query"
+QUICKNODE_API_KEY = os.environ["QUICKNODE_API_KEY"]
+CLUSTER_ID = "hyperliquid-core-mainnet"
+
+
+def run_query(sql: str) -> list[dict]:
+    """Send a SQL query to Quicknode SQL Explorer, return the result rows."""
+    resp = requests.post(
+        SQL_EXPLORER_URL,
+        headers={
+            "x-api-key": QUICKNODE_API_KEY,
+            "Content-Type": "application/json",
+        },
+        json={"query": sql, "clusterId": CLUSTER_ID},
+    )
+    resp.raise_for_status()
+    result = resp.json()
+    print(f"  {result['rows']} rows in {result['statistics']['elapsed']:.2f}s")
+    return result["data"]
+
+
+def get_platform_overview() -> list[dict]:
+    """Daily aggregate metrics for the last 7 days."""
+    return run_query("""
+        SELECT
+            day,
+            total_volume_usd,
+            total_fills,
+            active_traders,
+            total_fees,
+            liquidation_count,
+            liquidation_volume_usd
+        FROM hyperliquid_metrics_overview
+        WHERE day >= today() - INTERVAL 7 DAY
+        ORDER BY day ASC
+    """)
+
+
+def get_top_assets() -> list[dict]:
+    """Top 10 assets by 24h trading volume."""
+    return run_query("""
+        SELECT
+            coin,
+            count() AS trades,
+            round(sum(toFloat64(price) * toFloat64(size)), 2) AS volume_usd,
+            countDistinct(buyer_address) AS unique_buyers
+        FROM hyperliquid_trades
+        WHERE timestamp >= now() - INTERVAL 24 HOUR
+        GROUP BY coin
+        ORDER BY volume_usd DESC
+        LIMIT 10
+    """)
+
+
+def get_liquidations() -> list[dict]:
+    """Liquidation volume by coin over the last 24h.
+
+    The `user = liquidated_user` filter ensures each liquidation is counted
+    once (from the liquidated party's side), avoiding double-counting with
+    the counterparty fill.
+    """
+    return run_query("""
+        SELECT
+            coin,
+            countDistinct(liquidated_user) AS users_rekt,
+            count() AS liq_count,
+            round(sum(toFloat64(price) * toFloat64(size)), 2) AS liq_volume_usd
+        FROM hyperliquid_fills
+        WHERE is_liquidation = 1
+            AND user = liquidated_user
+            AND time >= now() - INTERVAL 24 HOUR
+        GROUP BY coin
+        ORDER BY liq_volume_usd DESC
+        LIMIT 10
+    """)
+
+
+def get_funding_extremes() -> list[dict]:
+    """Current funding rate extremes across all perpetual markets.
+
+    The annualized rate is calculated as: funding_rate * 8760 * 100
+    (per-hour rate -> yearly percentage).
+    """
+    return run_query("""
+        SELECT
+            coin,
+            round(toFloat64(funding) * 8760 * 100, 2) AS annualized_rate_pct,
+            round(toFloat64(open_interest) * toFloat64(mark_px), 2) AS oi_usd,
+            round(toFloat64(mark_px), 4) AS mark_price
+        FROM hyperliquid_perpetual_market_contexts
+        WHERE polled_at = (
+            SELECT max(polled_at)
+            FROM hyperliquid_perpetual_market_contexts
+        )
+        ORDER BY abs(toFloat64(funding)) DESC
+        LIMIT 10
+    """)

--- a/sql-explorer/hyperliquid-intel-bot/requirements.txt
+++ b/sql-explorer/hyperliquid-intel-bot/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.32.0
+python-dotenv>=1.0.1

--- a/sql-explorer/hyperliquid-intel-bot/typescript/.env.example
+++ b/sql-explorer/hyperliquid-intel-bot/typescript/.env.example
@@ -1,0 +1,3 @@
+QUICKNODE_API_KEY=your_quicknode_api_key
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token
+TELEGRAM_CHAT_ID=your_telegram_chat_id

--- a/sql-explorer/hyperliquid-intel-bot/typescript/package.json
+++ b/sql-explorer/hyperliquid-intel-bot/typescript/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "hyperliquid-intel-bot",
+  "version": "1.0.0",
+  "description": "Hyperliquid Intelligence Bot powered by Quicknode SQL Explorer",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/bot.ts",
+    "dry-run": "tsx src/bot.ts --dry-run",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/sql-explorer/hyperliquid-intel-bot/typescript/pnpm-lock.yaml
+++ b/sql-explorer/hyperliquid-intel-bot/typescript/pnpm-lock.yaml
@@ -1,0 +1,337 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      dotenv:
+        specifier: ^16.4.0
+        version: 16.6.1
+    devDependencies:
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.7:
+    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  dotenv@16.6.1: {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  resolve-pkg-maps@1.0.0: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.13.7
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}

--- a/sql-explorer/hyperliquid-intel-bot/typescript/src/bot.ts
+++ b/sql-explorer/hyperliquid-intel-bot/typescript/src/bot.ts
@@ -1,0 +1,76 @@
+/**
+ * Hyperliquid Intelligence Bot
+ *
+ * Queries Quicknode SQL Explorer for Hyperliquid market data, composes a
+ * formatted digest, and sends it to a Telegram channel.
+ *
+ * Usage:
+ *   npx tsx src/bot.ts              # run once, send digest immediately
+ *   npx tsx src/bot.ts --dry-run    # print digest without sending
+ *
+ * Guide: https://www.quicknode.com/guides/quicknode-products/sql-explorer/build-a-hyperliquid-intelligence-bot
+ */
+
+import "dotenv/config";
+import { formatDigest } from "./formatter.js";
+import {
+  getFundingExtremes,
+  getLiquidations,
+  getPlatformOverview,
+  getTopAssets,
+} from "./queries.js";
+
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN!;
+const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID!;
+
+/** Send a message to the configured Telegram chat. */
+async function sendTelegram(message: string): Promise<void> {
+  const url = `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`;
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      chat_id: TELEGRAM_CHAT_ID,
+      text: message,
+      parse_mode: "Markdown",
+    }),
+  });
+
+  if (!resp.ok) {
+    throw new Error(`Telegram error: ${resp.status} ${resp.statusText}`);
+  }
+
+  console.log(`Digest sent (chat_id=${TELEGRAM_CHAT_ID})`);
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+
+  console.log("Fetching digest data from SQL Explorer...");
+
+  process.stdout.write("Platform overview:");
+  const overview = await getPlatformOverview();
+
+  process.stdout.write("Top assets:");
+  const assets = await getTopAssets();
+
+  process.stdout.write("Liquidations:");
+  const liquidations = await getLiquidations();
+
+  process.stdout.write("Funding extremes:");
+  const funding = await getFundingExtremes();
+
+  const digest = formatDigest(overview, assets, liquidations, funding);
+  console.log(`\n${digest}`);
+
+  if (dryRun) {
+    console.log("\n[dry-run] Skipping Telegram send.");
+  } else {
+    await sendTelegram(digest);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/sql-explorer/hyperliquid-intel-bot/typescript/src/formatter.ts
+++ b/sql-explorer/hyperliquid-intel-bot/typescript/src/formatter.ts
@@ -79,7 +79,7 @@ export function formatDigest(
 
     lines.push("*Liquidations (24h)*");
     lines.push(`Total: ${formatNumber(totalLiq)}`);
-    lines.push(`Unique addresses: ${totalUsers.toLocaleString()}`);
+    lines.push(`Addresses liquidated: ${totalUsers.toLocaleString()}`);
 
     liquidations.slice(0, 3).forEach((row) => {
       const vol = formatNumber(Number(row.liq_volume_usd));

--- a/sql-explorer/hyperliquid-intel-bot/typescript/src/formatter.ts
+++ b/sql-explorer/hyperliquid-intel-bot/typescript/src/formatter.ts
@@ -1,0 +1,105 @@
+/**
+ * Digest formatting for Telegram delivery.
+ *
+ * Takes raw query result dictionaries and composes a Markdown-formatted
+ * message suitable for Telegram's "Markdown" parse mode.
+ */
+
+/** Format large numbers with K/M/B suffixes. */
+function formatNumber(n: number, prefix = "$"): string {
+  const absN = Math.abs(n);
+  const sign = n < 0 ? "-" : "";
+  if (absN >= 1_000_000_000) return `${sign}${prefix}${(absN / 1e9).toFixed(1)}B`;
+  if (absN >= 1_000_000) return `${sign}${prefix}${(absN / 1e6).toFixed(1)}M`;
+  if (absN >= 1_000) return `${sign}${prefix}${(absN / 1e3).toFixed(1)}K`;
+  return `${sign}${prefix}${absN.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+type Row = Record<string, string>;
+
+/** Compose all query results into a Telegram-ready digest. */
+export function formatDigest(
+  overview: Row[],
+  assets: Row[],
+  liquidations: Row[],
+  funding: Row[]
+): string {
+  const now = new Date().toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+
+  const lines: string[] = [];
+  lines.push("*Hyperliquid Daily Digest*");
+  lines.push(`_${now}_`);
+  lines.push("");
+
+  // Platform overview (aggregate the week)
+  if (overview.length > 0) {
+    const totalVol = overview.reduce((s, r) => s + Number(r.total_volume_usd), 0);
+    const totalFills = overview.reduce((s, r) => s + Number(r.total_fills), 0);
+    const peakTraders = Math.max(...overview.map((r) => Number(r.active_traders)));
+    const totalFees = overview.reduce((s, r) => s + Number(r.total_fees), 0);
+    const totalLiqVol = overview.reduce(
+      (s, r) => s + Number(r.liquidation_volume_usd),
+      0
+    );
+
+    lines.push("*Overview (7d)*");
+    lines.push(`Volume: ${formatNumber(totalVol)}`);
+    lines.push(`Fills: ${formatNumber(totalFills, "")}`);
+    lines.push(`Active traders: ${peakTraders.toLocaleString()}`);
+    lines.push(`Fees: ${formatNumber(totalFees)}`);
+    lines.push(`Liquidation volume: ${formatNumber(totalLiqVol)}`);
+    lines.push("");
+  }
+
+  // Top assets by volume
+  if (assets.length > 0) {
+    lines.push("*Top Assets by Volume (24h)*");
+    assets.slice(0, 5).forEach((row, i) => {
+      const vol = formatNumber(Number(row.volume_usd));
+      lines.push(`${i + 1}. ${row.coin}  ${vol}`);
+    });
+    lines.push("");
+  }
+
+  // Liquidations
+  if (liquidations.length > 0) {
+    const totalLiq = liquidations.reduce(
+      (s, r) => s + Number(r.liq_volume_usd),
+      0
+    );
+    const totalUsers = liquidations.reduce(
+      (s, r) => s + Number(r.users_rekt),
+      0
+    );
+
+    lines.push("*Liquidations (24h)*");
+    lines.push(`Total: ${formatNumber(totalLiq)}`);
+    lines.push(`Unique addresses: ${totalUsers.toLocaleString()}`);
+
+    liquidations.slice(0, 3).forEach((row) => {
+      const vol = formatNumber(Number(row.liq_volume_usd));
+      lines.push(`  ${row.coin}: ${vol} (${row.users_rekt} users)`);
+    });
+    lines.push("");
+  }
+
+  // Funding rate extremes
+  if (funding.length > 0) {
+    lines.push("*Funding Rate Extremes*");
+    funding.slice(0, 5).forEach((row) => {
+      const rate = Number(row.annualized_rate_pct);
+      const sign = rate > 0 ? "+" : "";
+      const oi = formatNumber(Number(row.oi_usd));
+      lines.push(`${row.coin}: ${sign}${rate}% ann.  OI ${oi}`);
+    });
+    lines.push("");
+  }
+
+  lines.push("_Powered by Quicknode SQL Explorer_");
+  return lines.join("\n");
+}

--- a/sql-explorer/hyperliquid-intel-bot/typescript/src/queries.ts
+++ b/sql-explorer/hyperliquid-intel-bot/typescript/src/queries.ts
@@ -1,0 +1,119 @@
+/**
+ * SQL Explorer query definitions and REST API client.
+ *
+ * Each function wraps a SQL query and sends it to the Quicknode SQL Explorer
+ * REST API. The SQL is standard ClickHouse-compatible syntax.
+ */
+
+const SQL_EXPLORER_URL = "https://api.quicknode.com/sql/rest/v1/query";
+const QUICKNODE_API_KEY = process.env.QUICKNODE_API_KEY!;
+const CLUSTER_ID = "hyperliquid-core-mainnet";
+
+interface QueryResult<T = Record<string, string>> {
+  data: T[];
+  meta: { name: string; type: string }[];
+  rows: number;
+  statistics: { elapsed: number; rows_read: number; bytes_read: number };
+}
+
+/** Send a SQL query to Quicknode SQL Explorer, return the result rows. */
+export async function runQuery<T = Record<string, string>>(
+  sql: string
+): Promise<T[]> {
+  const resp = await fetch(SQL_EXPLORER_URL, {
+    method: "POST",
+    headers: {
+      "x-api-key": QUICKNODE_API_KEY,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query: sql, clusterId: CLUSTER_ID }),
+  });
+
+  if (!resp.ok) {
+    throw new Error(`SQL Explorer error: ${resp.status} ${resp.statusText}`);
+  }
+
+  const result: QueryResult<T> = await resp.json();
+  console.log(`  ${result.rows} rows in ${result.statistics.elapsed.toFixed(2)}s`);
+  return result.data;
+}
+
+/** Daily aggregate metrics for the last 7 days. */
+export async function getPlatformOverview() {
+  return runQuery(`
+    SELECT
+      day,
+      total_volume_usd,
+      total_fills,
+      active_traders,
+      total_fees,
+      liquidation_count,
+      liquidation_volume_usd
+    FROM hyperliquid_metrics_overview
+    WHERE day >= today() - INTERVAL 7 DAY
+    ORDER BY day ASC
+  `);
+}
+
+/** Top 10 assets by 24h trading volume. */
+export async function getTopAssets() {
+  return runQuery(`
+    SELECT
+      coin,
+      count() AS trades,
+      round(sum(toFloat64(price) * toFloat64(size)), 2) AS volume_usd,
+      countDistinct(buyer_address) AS unique_buyers
+    FROM hyperliquid_trades
+    WHERE timestamp >= now() - INTERVAL 24 HOUR
+    GROUP BY coin
+    ORDER BY volume_usd DESC
+    LIMIT 10
+  `);
+}
+
+/**
+ * Liquidation volume by coin over the last 24h.
+ *
+ * The `user = liquidated_user` filter ensures each liquidation is counted
+ * once (from the liquidated party's side), avoiding double-counting with
+ * the counterparty fill.
+ */
+export async function getLiquidations() {
+  return runQuery(`
+    SELECT
+      coin,
+      countDistinct(liquidated_user) AS users_rekt,
+      count() AS liq_count,
+      round(sum(toFloat64(price) * toFloat64(size)), 2) AS liq_volume_usd
+    FROM hyperliquid_fills
+    WHERE is_liquidation = 1
+      AND user = liquidated_user
+      AND time >= now() - INTERVAL 24 HOUR
+    GROUP BY coin
+    ORDER BY liq_volume_usd DESC
+    LIMIT 10
+  `);
+}
+
+/**
+ * Current funding rate extremes across all perpetual markets.
+ *
+ * The annualized rate is calculated as: funding_rate * 8760 * 100
+ * (per-hour rate -> yearly percentage).
+ */
+export async function getFundingExtremes() {
+  return runQuery(`
+    SELECT
+      coin,
+      round(toFloat64(funding) * 8760 * 100, 2) AS annualized_rate_pct,
+      round(toFloat64(open_interest) * toFloat64(mark_px), 2) AS oi_usd,
+      round(toFloat64(mark_px), 4) AS mark_price
+    FROM hyperliquid_perpetual_market_contexts
+    WHERE polled_at = (
+      SELECT max(polled_at)
+      FROM hyperliquid_perpetual_market_contexts
+    )
+    ORDER BY abs(toFloat64(funding)) DESC
+    LIMIT 10
+  `);
+}

--- a/sql-explorer/hyperliquid-intel-bot/typescript/src/queries.ts
+++ b/sql-explorer/hyperliquid-intel-bot/typescript/src/queries.ts
@@ -6,7 +6,10 @@
  */
 
 const SQL_EXPLORER_URL = "https://api.quicknode.com/sql/rest/v1/query";
-const QUICKNODE_API_KEY = process.env.QUICKNODE_API_KEY!;
+const QUICKNODE_API_KEY = process.env.QUICKNODE_API_KEY;
+if (!QUICKNODE_API_KEY) {
+  throw new Error("Set QUICKNODE_API_KEY in your .env file before running the bot.");
+}
 const CLUSTER_ID = "hyperliquid-core-mainnet";
 
 interface QueryResult<T = Record<string, string>> {

--- a/sql-explorer/hyperliquid-intel-bot/typescript/tsconfig.json
+++ b/sql-explorer/hyperliquid-intel-bot/typescript/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Sample implementations (Python + TypeScript) for the SQL Explorer guide. Queries REST API, composes market digest, sends to Telegram on schedule.

- Python: bot.py, queries.py, formatter.py
- TypeScript: Native fetch, strict types, tsx runner
- Full env setup docs in README
- Supports --dry-run mode for testing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New standalone example code and documentation; no modifications to existing production paths, with risk mainly limited to correct env configuration and external API calls (Quicknode/Telegram).
> 
> **Overview**
> Adds a new `sql-explorer/hyperliquid-intel-bot` sample app that queries Quicknode SQL Explorer for Hyperliquid market data, formats a daily Markdown digest, and (optionally via `--dry-run`) posts it to Telegram.
> 
> Includes complete setup/run docs, `.env.example` templates, Python dependencies, and a TypeScript implementation with `pnpm` tooling (`tsx` runner, `tsconfig`, lockfile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de71d6918443267b97c31d895b9747df50c5c4c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->