### PR TITLE
[CON-775] Update Jupiter Trading Bot Sample App

### DIFF
--- a/solana/jupiter-bot/.env.example
+++ b/solana/jupiter-bot/.env.example
@@ -1,4 +1,4 @@
-# Replace with your Your Solana wallet secret key
+# Replace with your Solana wallet secret key
 SECRET_KEY=[]
 # Replace with your Quicknode Solana Mainnet RPC endpoint
 SOLANA_ENDPOINT=https://your-solana-mainnet-rpc-endpoint.quiknode.pro/abc123/

--- a/solana/jupiter-bot/.env.example
+++ b/solana/jupiter-bot/.env.example
@@ -2,5 +2,5 @@
 SECRET_KEY=[]
 # Replace with your Quicknode Solana Mainnet RPC endpoint
 SOLANA_ENDPOINT=https://your-solana-mainnet-rpc-endpoint.quiknode.pro/abc123/
-# Replace with your Quicknode Jupiter API endpoint (or a public one: https://www.jupiterapi.com/)
+# Replace with your Quicknode Jupiter API endpoint (or a public one: https://public.jupiterapi.com/)
 METIS_ENDPOINT=https://jupiter-swap-api.quiknode.pro/abc123/

--- a/solana/jupiter-bot/.env.example
+++ b/solana/jupiter-bot/.env.example
@@ -1,3 +1,6 @@
-SECRET_KEY=[00, 00, 00, ... 00, 00, 00]
-SOLANA_ENDPOINT=https://example.solana-mainnet.quiknode.pro/x123456/
-METIS_ENDPOINT=https://jupiter-swap-api.quiknode.pro/ABC1234586
+# Replace with your Your Solana wallet secret key
+SECRET_KEY=[]
+# Replace with your Quicknode Solana Mainnet RPC endpoint
+SOLANA_ENDPOINT=https://your-solana-mainnet-rpc-endpoint.quiknode.pro/abc123/
+# Replace with your Quicknode Jupiter API endpoint (or a public one: https://www.jupiterapi.com/)
+METIS_ENDPOINT=https://jupiter-swap-api.quiknode.pro/abc123/

--- a/solana/jupiter-bot/.gitignore
+++ b/solana/jupiter-bot/.gitignore
@@ -1,0 +1,27 @@
+# Dependencies
+node_modules/
+
+# Environment and secrets
+.env
+.env.*
+!.env.example
+
+# Runtime / local state
+trades.json
+
+# Build output
+dist/
+build/
+*.tsbuildinfo
+
+# Logs and debug
+*.log
+npm-debug.log*
+
+# OS
+.DS_Store
+
+# IDE (optional local settings)
+.idea/
+.cursor/
+.claude/

--- a/solana/jupiter-bot/README.md
+++ b/solana/jupiter-bot/README.md
@@ -1,35 +1,37 @@
 # Jupiter Trading Bot Example
 
 ## Overview
-This is a simple demo uses Jupiter's v6 API and Quicknode's Metis add-on to create a simple Solana trading bot. The bot monitors price differences between token pairs and executes trades when profitable opportunities arise.
+
+This is a simple demo uses Jupiter's Metis API and Quicknode's Metis add-on to create a simple Solana trading bot. The bot monitors price differences between token pairs and executes trades when profitable opportunities arise.
 
 _This example is for educational purposes only. Quicknode does not provide financial advice or endorse any trading strategies. Always do your own research and consult with a financial advisor before making any investment decisions._
 
 The demo uses:
-- [Solana Web3.js - 1.x](https://github.com/solana-labs/solana-web3.js/)
-- [SPL Token SDK](https://www.npmjs.com/package/@solana/spl-token)
-- [Jupiter API SDK](https://www.npmjs.com/package/@jup-ag/api)
+
+- [Solana Kit](https://github.com/anza-xyz/kit) (`@solana/kit`)
+- [Token program client](https://github.com/solana-program/token) (`@solana-program/token`)
+- [Address Lookup Table client](https://github.com/solana-program/address-lookup-table) (`@solana-program/address-lookup-table`)
+- [Jupiter Quote API TypeScript client](https://github.com/jup-ag/jupiter-quote-api-node) (`@jup-ag/api`)
 
 Supporting resources:
+
 - [Written Guide - Create a Solana Trading Bot Using Jupiter API](https://www.quicknode.com/guides/solana-development/3rd-party-integrations/jupiter-api-trading-bot)
 - [Video Guide - How to Create a Solana Trading Bot](https://www.youtube.com/watch?v=u8Qr1JI3pUM)
-
 
 ## Getting Started
 
 ### Install Dependencies
 
-Open the project dictory: 
+Open the project directory:
 
 ```bash
 cd solana/jupiter-bot
 ```
+
 Then, install the dependencies:
 
 ```bash
 npm install
-# or
-yarn
 # or
 pnpm install
 # or
@@ -38,17 +40,16 @@ bun install
 
 ### Set Environment Variables
 
-Make sure you have a Quicknode endpoint handy--you can get one free [here](https://www.quicknode.com/signup?utm_source=internal&utm_campaign=dapp-examples&utm_content=solana-staking-ui).
+Make sure you have a Quicknode endpoint handy. You can [get one here](https://www.quicknode.com/signup?utm_source=internal&utm_campaign=qn-guide-examples&utm_content=jupiter-bot).
 
-- Rename `.env.example` to `.env` and update with your Quicknode Solana Node Endpoint.
-- Specify your `SECRET_KEY` (the private key of the wallet you want to use for the bot) -- you can generate a new one with `solana-keygen new` command using the Solana CLI.
-- Specify your `SOLANA_ENDPOINT` (get one [here](https://www.quicknode.com/signup?utm_source=internal&utm_campaign=sample-apps&utm_content=jupiter-api-trading-bot)) and `METIS_ENDPOINT` (get one [here](https://marketplace.quicknode.com/add-on/metis-jupiter-v6-swap-api?_gl=1*jztoq8*_gcl_au*NTA3NDE0ODY0LjE3MzY0NDI2MDA.*_ga*MTY4NjIxODQzMi4xNjkwNjY3NjQ5*_ga_DYE4XLEMH3*MTc0MzQ0NDYyOC43LjEuMTc0MzQ0NTgwMC40OS4wLjA)) or use the public endpoint, `https://public.jupiterapi.com`.
-
+- Rename `.env.example` to `.env` and update with your Quicknode Solana Node and Metis Add-on Endpoints.
+- Specify your `SECRET_KEY` (the private key of the wallet you want to use for the bot). You can generate a new one with `solana-keygen new` command using the Solana CLI.
+- Specify your `SOLANA_ENDPOINT` ([get one here](https://www.quicknode.com/signup?utm_source=internal&utm_campaign=sample-apps&utm_content=jupiter-api-trading-bot)) and `METIS_ENDPOINT` ([get one here](https://marketplace.quicknode.com/add-on/metis-jupiter-swap-api)) or use the public endpoint, `https://public.jupiterapi.com`.
 
 ```sh
-SECRET_KEY=[00, 00, 00, ... 00, 00, 00]
-SOLANA_ENDPOINT=https://example.solana-mainnet.quiknode.pro/x123456/
-METIS_ENDPOINT=https://public.jupiterapi.com
+SECRET_KEY=[00, ..., 00]
+SOLANA_ENDPOINT=https://example.solana-mainnet.quiknode.pro/abc123/
+METIS_ENDPOINT=https://jupiter-swap-api.quiknode.pro/abc123
 ```
 
 Ensure your wallet is funded and modify the trading strategy in `bot.ts` to suit your needs.
@@ -58,13 +59,10 @@ First, run the development server:
 ```bash
 npm run start
 # or
-yarn start
-# or
 pnpm start
 # or
 bun start
 ```
-
 
 ## How it Works
 
@@ -91,12 +89,14 @@ The main class that handles all trading logic:
 - **logSwap**: Records successful trades to a JSON file
 - **updateNextTrade**: Prepares for the next trade after a successful swap
 - **terminateSession**: Safely shuts down the bot when conditions require it
-- **instructionDataToTransactionInstruction**: Converts Jupiter API instruction format to Solana transaction instructions
-- **getAdressLookupTableAccounts**: Fetches address lookup tables for optimized transactions
+- **jupiterInstructionToKitInstruction**: Converts Jupiter API instruction format to `@solana/kit` instructions
+- **getAddressLookupTableAccounts**: Fetches address lookup tables for optimized transactions
 - **postTransactionProcessing**: Handles tasks after a successful transaction
+
 ### Main Application
 
 A simple runner script that:
+
 - Loads environment variables
 - Creates an instance of the ArbBot with configuration
 - Initializes and starts the bot
@@ -104,9 +104,8 @@ A simple runner script that:
 ## Example Trading Strategy
 
 The bot uses a simple arbitrage strategy:
+
 1. Start with an initial token (USDC or SOL)
 2. Execute a trade when the price exceeds the target threshold
 3. Update parameters for the reverse trade with a profit margin
 4. Continue the cycle as long as profitable opportunities exist
-
-_This example is for educational purposes only. Quicknode does not provide financial advice or endorse any trading strategies. Always do your own research and consult with a financial advisor before making any investment decisions._

--- a/solana/jupiter-bot/bot.ts
+++ b/solana/jupiter-bot/bot.ts
@@ -1,17 +1,11 @@
-import { Keypair, Connection, PublicKey, VersionedTransaction, LAMPORTS_PER_SOL, TransactionInstruction, AddressLookupTableAccount, TransactionMessage } from "@solana/web3.js";
-import { createJupiterApiClient, DefaultApi, ResponseError, QuoteGetRequest, QuoteResponse, Instruction, AccountMeta } from '@jup-ag/api';
-import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import { createSolanaRpc, createSolanaRpcSubscriptions, address, Address, KeyPairSigner, createKeyPairSignerFromBytes, Instruction, AccountRole, pipe, createTransactionMessage, setTransactionMessageFeePayerSigner, setTransactionMessageLifetimeUsingBlockhash, appendTransactionMessageInstructions, compressTransactionMessageUsingAddressLookupTables, signTransactionMessageWithSigners, getSignatureFromTransaction, sendAndConfirmTransactionFactory, AddressesByLookupTableAddress } from "@solana/kit";
+import { createJupiterApiClient, SwapApi, ResponseError, QuoteGetRequest, QuoteResponse, Instruction as JupiterInstruction, AccountMeta } from '@jup-ag/api';
+import { findAssociatedTokenPda } from "@solana-program/token";
+import { fetchAddressLookupTable } from "@solana-program/address-lookup-table";
 import * as fs from 'fs';
 import * as path from 'path';
 
-interface LogSwapArgs {
-    inputToken: string;
-    inAmount: string;
-    outputToken: string;
-    outAmount: string;
-    txId: string;
-    timestamp: string;
-}
+const LAMPORTS_PER_SOL = 1_000_000_000n;
 
 interface ArbBotConfig {
     solanaEndpoint: string; // e.g., "https://ex-am-ple.solana-mainnet.quiknode.pro/123456/"
@@ -33,14 +27,26 @@ export enum SwapToken {
     USDC
 }
 
+interface LogSwapArgs {
+    inputToken: string;
+    inAmount: string;
+    outputToken: string;
+    outAmount: string;
+    txId: string;
+    timestamp: string;
+}
+
 export class ArbBot {
-    private solanaConnection: Connection;
-    private jupiterApi: DefaultApi;
-    private wallet: Keypair;
-    private usdcMint: PublicKey = new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
-    private solMint: PublicKey = new PublicKey("So11111111111111111111111111111111111111112");
-    private usdcTokenAccount: PublicKey;
-    private solBalance: number = 0;
+    private rpc: ReturnType<typeof createSolanaRpc>;
+    private rpcSubscriptions: ReturnType<typeof createSolanaRpcSubscriptions>;
+    private sendAndConfirmTransaction!: ReturnType<typeof sendAndConfirmTransactionFactory>;
+    private jupiterApi: SwapApi;
+    private wallet!: KeyPairSigner;
+    private secretKey: Uint8Array;
+    private usdcMint: Address = address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+    private solMint: Address = address("So11111111111111111111111111111111111111112");
+    private usdcTokenAccount!: Address;
+    private solBalance: bigint = 0n;
     private usdcBalance: number = 0;
     private checkInterval: number = 1000 * 10; 
     private lastCheck: number = 0;
@@ -60,25 +66,64 @@ export class ArbBot {
             initialInputAmount,
             firstTradePrice
         } = config;
-        this.solanaConnection = new Connection(solanaEndpoint);
+        this.rpc = createSolanaRpc(solanaEndpoint);
+        this.rpcSubscriptions = createSolanaRpcSubscriptions(solanaEndpoint.replace('https://', 'wss://'));
         this.jupiterApi = createJupiterApiClient({ basePath: metisEndpoint });
-        this.wallet = Keypair.fromSecretKey(secretKey);
-        this.usdcTokenAccount = getAssociatedTokenAddressSync(this.usdcMint, this.wallet.publicKey);
+        this.secretKey = secretKey;
         if (targetGainPercentage) { this.targetGainPercentage = targetGainPercentage }
         if (checkInterval) { this.checkInterval = checkInterval }
         this.nextTrade = {
-            inputMint: initialInputToken === SwapToken.SOL ? this.solMint.toBase58() : this.usdcMint.toBase58(),
-            outputMint: initialInputToken === SwapToken.SOL ? this.usdcMint.toBase58() : this.solMint.toBase58(),
+            inputMint: initialInputToken === SwapToken.SOL ? this.solMint : this.usdcMint,
+            outputMint: initialInputToken === SwapToken.SOL ? this.usdcMint : this.solMint,
             amount: initialInputAmount,
+            slippageBps: 300,
             nextTradeThreshold: firstTradePrice,
         };
     }
 
     async init(): Promise<void> {
-        console.log(`🤖 Initiating arb bot for wallet: ${this.wallet.publicKey.toBase58()}.`)
+        this.wallet = await createKeyPairSignerFromBytes(this.secretKey);
+        this.sendAndConfirmTransaction = sendAndConfirmTransactionFactory({ rpc: this.rpc, rpcSubscriptions: this.rpcSubscriptions });
+        const [usdcTokenAccount] = await findAssociatedTokenPda({
+            mint: this.usdcMint,
+            owner: this.wallet.address,
+            tokenProgram: address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+        });
+        this.usdcTokenAccount = usdcTokenAccount;
+        console.log(`🤖 Initiating arb bot for wallet: ${this.wallet.address}.`)
         await this.refreshBalances();
-        console.log(`🏦 Current balances:\nSOL: ${this.solBalance / LAMPORTS_PER_SOL},\nUSDC: ${this.usdcBalance}`);
+        console.log(`🏦 Current balances:\nSOL: ${Number(this.solBalance) / Number(LAMPORTS_PER_SOL)},\nUSDC: ${this.usdcBalance}`);
         this.initiatePriceWatch();
+    }
+
+    private async refreshBalances(): Promise<void> {
+        try {
+            const results = await Promise.allSettled([
+                this.rpc.getBalance(this.wallet.address).send(),
+                this.rpc.getTokenAccountBalance(this.usdcTokenAccount).send()
+            ]);
+
+            const solBalanceResult = results[0];
+            const usdcBalanceResult = results[1];
+
+            if (solBalanceResult.status === 'fulfilled') {
+                this.solBalance = solBalanceResult.value.value;
+            } else {
+                console.error('Error fetching SOL balance:', solBalanceResult.reason);
+            }
+
+            if (usdcBalanceResult.status === 'fulfilled') {
+                this.usdcBalance = usdcBalanceResult.value.value.uiAmount ?? 0;
+            } else {
+                this.usdcBalance = 0;
+            }
+
+            if (this.solBalance < LAMPORTS_PER_SOL / 100n) {
+                this.terminateSession("Low SOL balance.");
+            }
+        } catch (error) {
+            console.error('Unexpected error during balance refresh:', error);
+        }
     }
 
     private initiatePriceWatch(): void {
@@ -143,44 +188,39 @@ export class ArbBot {
             } = await this.jupiterApi.swapInstructionsPost({
                 swapRequest: {
                     quoteResponse: route,
-                    userPublicKey: this.wallet.publicKey.toBase58(),
-                    prioritizationFeeLamports: 'auto'
+                    userPublicKey: this.wallet.address,
+                    prioritizationFeeLamports: {
+                        priorityLevelWithMaxLamports: {
+                            priorityLevel: 'high',
+                            maxLamports: 1_000_000,
+                        }
+                    }
                 },
             });
 
-            const instructions: TransactionInstruction[] = [
-                ...computeBudgetInstructions.map(this.instructionDataToTransactionInstruction),
-                ...setupInstructions.map(this.instructionDataToTransactionInstruction),
-                this.instructionDataToTransactionInstruction(swapInstruction),
-                this.instructionDataToTransactionInstruction(cleanupInstruction),
-            ].filter((ix) => ix !== null) as TransactionInstruction[];
+            const instructions: Instruction[] = [
+                ...computeBudgetInstructions.map(this.jupiterInstructionToKitInstruction.bind(this)),
+                ...setupInstructions.map(this.jupiterInstructionToKitInstruction.bind(this)),
+                this.jupiterInstructionToKitInstruction(swapInstruction),
+                this.jupiterInstructionToKitInstruction(cleanupInstruction),
+            ].filter((ix): ix is Instruction => ix !== null);
 
-            const addressLookupTableAccounts = await this.getAdressLookupTableAccounts(
-                addressLookupTableAddresses,
-                this.solanaConnection
+            const alts = await this.getAddressLookupTableAccounts(addressLookupTableAddresses);
+
+            const { value: latestBlockhash } = await this.rpc.getLatestBlockhash().send();
+
+            const message = pipe(
+                createTransactionMessage({ version: 0 }),
+                (m) => setTransactionMessageFeePayerSigner(this.wallet, m),
+                (m) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),
+                (m) => appendTransactionMessageInstructions(instructions, m),
+                (m) => compressTransactionMessageUsingAddressLookupTables(m, alts),
             );
 
-            const { blockhash, lastValidBlockHeight } = await this.solanaConnection.getLatestBlockhash();
-
-            const messageV0 = new TransactionMessage({
-                payerKey: this.wallet.publicKey,
-                recentBlockhash: blockhash,
-                instructions,
-            }).compileToV0Message(addressLookupTableAccounts);
-
-            const transaction = new VersionedTransaction(messageV0);
-            transaction.sign([this.wallet]);
-
-            const rawTransaction = transaction.serialize();
-            const txid = await this.solanaConnection.sendRawTransaction(rawTransaction, {
-                skipPreflight: true,
-                maxRetries: 2
-            });
-            const confirmation = await this.solanaConnection.confirmTransaction({ signature: txid, blockhash, lastValidBlockHeight }, 'confirmed');
-            if (confirmation.value.err) {
-                throw new Error('Transaction failed');
-            }            
-            await this.postTransactionProcessing(route, txid);
+            const signedTx = await signTransactionMessageWithSigners(message);
+            const signature = getSignatureFromTransaction(signedTx);
+            await this.sendAndConfirmTransaction(signedTx, { commitment: 'confirmed', skipPreflight: true });
+            await this.postTransactionProcessing(route, signature);
         } catch (error) {
             if (error instanceof ResponseError) {
                 console.log(await error.response.json());
@@ -194,34 +234,15 @@ export class ArbBot {
         }
     }
 
-    private async refreshBalances(): Promise<void> {
-        try {
-            const results = await Promise.allSettled([
-                this.solanaConnection.getBalance(this.wallet.publicKey),
-                this.solanaConnection.getTokenAccountBalance(this.usdcTokenAccount)
-            ]);
-
-            const solBalanceResult = results[0];
-            const usdcBalanceResult = results[1];
-
-            if (solBalanceResult.status === 'fulfilled') {
-                this.solBalance = solBalanceResult.value;
-            } else {
-                console.error('Error fetching SOL balance:', solBalanceResult.reason);
-            }
-
-            if (usdcBalanceResult.status === 'fulfilled') {
-                this.usdcBalance = usdcBalanceResult.value.value.uiAmount ?? 0;
-            } else {
-                this.usdcBalance = 0;
-            }
-
-            if (this.solBalance < LAMPORTS_PER_SOL / 100) {
-                this.terminateSession("Low SOL balance.");
-            }
-        } catch (error) {
-            console.error('Unexpected error during balance refresh:', error);
-        }
+    private async updateNextTrade(lastTrade: QuoteResponse): Promise<void> {
+        const priceChange = this.targetGainPercentage / 100;
+        this.nextTrade = {
+            inputMint: this.nextTrade.outputMint,
+            outputMint: this.nextTrade.inputMint,
+            amount: parseInt(lastTrade.outAmount),
+            slippageBps: 300,
+            nextTradeThreshold: parseInt(lastTrade.inAmount) * (1 + priceChange),
+        };
     }
 
     private async logSwap(args: LogSwapArgs): Promise<void> {
@@ -252,19 +273,9 @@ export class ArbBot {
         }
     }
 
-    private async updateNextTrade(lastTrade: QuoteResponse): Promise<void> {
-        const priceChange = this.targetGainPercentage / 100;
-        this.nextTrade = {
-            inputMint: this.nextTrade.outputMint,
-            outputMint: this.nextTrade.inputMint,
-            amount: parseInt(lastTrade.outAmount),
-            nextTradeThreshold: parseInt(lastTrade.inAmount) * (1 + priceChange),
-        };
-    }
-
     private terminateSession(reason: string): void {
         console.warn(`❌ Terminating bot...${reason}`);
-        console.log(`Current balances:\nSOL: ${this.solBalance / LAMPORTS_PER_SOL},\nUSDC: ${this.usdcBalance}`);
+        console.log(`Current balances:\nSOL: ${Number(this.solBalance) / Number(LAMPORTS_PER_SOL)},\nUSDC: ${this.usdcBalance}`);
         if (this.priceWatchIntervalId) {
             clearInterval(this.priceWatchIntervalId);
             this.priceWatchIntervalId = undefined; // Clear the reference to the interval
@@ -275,41 +286,34 @@ export class ArbBot {
         }, 1000);
     }
 
-    private instructionDataToTransactionInstruction (
-        instruction: Instruction | undefined
-    ) {
+    private jupiterInstructionToKitInstruction(
+        instruction: JupiterInstruction | undefined
+    ): Instruction | null {
         if (instruction === null || instruction === undefined) return null;
-        return new TransactionInstruction({
-            programId: new PublicKey(instruction.programId),
-            keys: instruction.accounts.map((key: AccountMeta) => ({
-                pubkey: new PublicKey(key.pubkey),
-                isSigner: key.isSigner,
-                isWritable: key.isWritable,
+        return {
+            programAddress: address(instruction.programId),
+            accounts: instruction.accounts.map((key: AccountMeta) => ({
+                address: address(key.pubkey),
+                role: key.isWritable && key.isSigner ? AccountRole.WRITABLE_SIGNER
+                    : key.isSigner ? AccountRole.READONLY_SIGNER
+                    : key.isWritable ? AccountRole.WRITABLE
+                    : AccountRole.READONLY,
             })),
-            data: Buffer.from(instruction.data, "base64"),
-        });
+            data: new Uint8Array(Buffer.from(instruction.data, 'base64')),
+        };
     };
 
-    private async getAdressLookupTableAccounts (
-        keys: string[], connection: Connection
-    ): Promise<AddressLookupTableAccount[]> {
-        const addressLookupTableAccountInfos =
-            await connection.getMultipleAccountsInfo(
-                keys.map((key) => new PublicKey(key))
-            );
-    
-        return addressLookupTableAccountInfos.reduce((acc, accountInfo, index) => {
-            const addressLookupTableAddress = keys[index];
-            if (accountInfo) {
-                const addressLookupTableAccount = new AddressLookupTableAccount({
-                    key: new PublicKey(addressLookupTableAddress),
-                    state: AddressLookupTableAccount.deserialize(accountInfo.data),
-                });
-                acc.push(addressLookupTableAccount);
-            }
-    
-            return acc;
-        }, new Array<AddressLookupTableAccount>());
+    private async getAddressLookupTableAccounts(
+        keys: string[]
+    ): Promise<AddressesByLookupTableAddress> {
+        const result: AddressesByLookupTableAddress = {};
+        await Promise.all(
+            keys.map(async (key) => {
+                const altAccount = await fetchAddressLookupTable(this.rpc, address(key));
+                result[address(key)] = altAccount.data.addresses;
+            })
+        );
+        return result;
     };
 
     private async postTransactionProcessing(quote: QuoteResponse, txid: string): Promise<void> {
@@ -319,3 +323,5 @@ export class ArbBot {
         await this.logSwap({ inputToken: inputMint, inAmount, outputToken: outputMint, outAmount, txId: txid, timestamp: new Date().toISOString() });
     }
 }
+
+

--- a/solana/jupiter-bot/index.ts
+++ b/solana/jupiter-bot/index.ts
@@ -1,14 +1,8 @@
-import { LAMPORTS_PER_SOL, clusterApiUrl } from "@solana/web3.js";
 import { ArbBot, SwapToken } from './bot';
-import dotenv from "dotenv";
-
-dotenv.config({
-    path: ".env",
-});
 
 const defaultConfig = {
-    solanaEndpoint: clusterApiUrl("mainnet-beta"),
-    jupiter: "https://public.jupiterapi.com",
+    solanaEndpoint: 'https://api.mainnet-beta.solana.com',
+    jupiter: "https://quote-api.jup.ag/v6",
 };
 
 async function main() {
@@ -21,13 +15,14 @@ async function main() {
         solanaEndpoint: process.env.SOLANA_ENDPOINT ?? defaultConfig.solanaEndpoint,
         metisEndpoint: process.env.METIS_ENDPOINT ?? defaultConfig.jupiter,
         secretKey: decodedSecretKey,
-        firstTradePrice: 0.1 * LAMPORTS_PER_SOL,
-        targetGainPercentage: 0.15,
-        initialInputToken: SwapToken.USDC,
-        initialInputAmount: 10_000_000,
+        firstTradePrice: 900_000,       // min USDC out (6 decimals) — $0.90 for 0.01 SOL at ~$90/SOL
+        targetGainPercentage: 1.5,
+        initialInputToken: SwapToken.SOL,
+        initialInputAmount: 10_000_000, // 0.01 SOL in lamports
     });
 
-    await bot.init();
+    console.log("Metis", process.env.METIS_ENDPOINT ?? defaultConfig.jupiter)
+    //await bot.init();
 
 }
 

--- a/solana/jupiter-bot/index.ts
+++ b/solana/jupiter-bot/index.ts
@@ -2,7 +2,7 @@ import { ArbBot, SwapToken } from './bot';
 
 const defaultConfig = {
     solanaEndpoint: 'https://api.mainnet-beta.solana.com',
-    jupiter: "https://quote-api.jup.ag/v6",
+    jupiter: "https://public.jupiterapi.com",
 };
 
 async function main() {
@@ -21,9 +21,7 @@ async function main() {
         initialInputAmount: 10_000_000, // 0.01 SOL in lamports
     });
 
-    console.log("Metis", process.env.METIS_ENDPOINT ?? defaultConfig.jupiter)
-    //await bot.init();
-
+    await bot.init();
 }
 
 main().catch(console.error);

--- a/solana/jupiter-bot/package-lock.json
+++ b/solana/jupiter-bot/package-lock.json
@@ -1,0 +1,1127 @@
+{
+  "name": "qn-jupiter-trading-bot-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "qn-jupiter-trading-bot-test",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@jup-ag/api": "^6.0.48",
+        "@solana-program/address-lookup-table": "^0.11.0",
+        "@solana-program/token": "^0.13.0",
+        "@solana/kit": "^6.9.0"
+      },
+      "devDependencies": {
+        "@types/node": "^25.7.0"
+      }
+    },
+    "node_modules/@jup-ag/api": {
+      "version": "6.0.48",
+      "resolved": "https://registry.npmjs.org/@jup-ag/api/-/api-6.0.48.tgz",
+      "integrity": "sha512-H66m/cIqdVIA0qLI2X76UOhuMXkS/+uI6e4KQuU3fn6FSBhCX/9fwt/4IdwES4KWXwGtvqhsg2ExkB9tRtNhyA==",
+      "license": "MIT"
+    },
+    "node_modules/@solana-program/address-lookup-table": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/address-lookup-table/-/address-lookup-table-0.11.0.tgz",
+      "integrity": "sha512-loC6VTEhmhYSq2ElZrv+V9uHp/Te6A7rllLIArk9c3A5+5V7sRhVsxZvsPGcv/WMXLgqmXR+Vl7WF7QSV3tXNQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^6.0"
+      }
+    },
+    "node_modules/@solana-program/system": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.12.0.tgz",
+      "integrity": "sha512-ZnAAWeGVMWNtJhw3GdifI2HnhZ0A0H0qs8tBkcFvxp/8wIavvO+GOM4Jd0N22u2+Lni2zcwvcrxrsxj6Mjphng==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^6.1.0"
+      }
+    },
+    "node_modules/@solana-program/token": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.13.0.tgz",
+      "integrity": "sha512-/Apjrd5lwOJGrPB0J5Rv7EBeclvyEBQPAGA85Scm7wBH+GpkbdLDM9uK3TNg8jjFKyWQYai/JtPHbrx7VgFLSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana-program/system": "^0.12.0"
+      },
+      "peerDependencies": {
+        "@solana/kit": "^6.5.0"
+      }
+    },
+    "node_modules/@solana/accounts": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-6.9.0.tgz",
+      "integrity": "sha512-g36AJreJrgf9AAjOfbdFHEFUTymBgzbWHoEDElZ+fDKvqBINDiUVKzDApwc7C7kGPMFqQBaoEHnQRxf2IqfKZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/rpc-spec": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/addresses": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
+      "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/assertions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
+      "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-6.9.0.tgz",
+      "integrity": "sha512-oWOybKa1PTGI1D/FyrvGKralADM1jmVZC2AtgEo+4JTKG0+i1p9ZbwNY2UcJqdYsDMDaGHAx0LMAid9LDCxXTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/fixed-points": "6.9.0",
+        "@solana/options": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-data-structures": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.9.0.tgz",
+      "integrity": "sha512-f7GYtiHafvJDhqiwzUUSr/6AYSK4DCw6quPmA80NZGtkNiFa+g6LoJy2wbC0wp2dxvCwNpxf6x3ILCYRutAvvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/fast-stable-stringify": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-6.9.0.tgz",
+      "integrity": "sha512-l14zGVsURbT5Aox/kLFQywqV4VaE9/j3h2EvCu9oULVPMwzQB6yezJb1/KyiDwhm/RscooPd0gFQFIKEGQbayw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/fixed-points": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/fixed-points/-/fixed-points-6.9.0.tgz",
+      "integrity": "sha512-0K7mbYC4jdAZFlXqXjpNanmEyZxk7K9NtXDLc1zuhGuxwH8J9guvohwdw2V7TQ9bfjCYsprY3Tp2kUVQpECGmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/functional": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.9.0.tgz",
+      "integrity": "sha512-sgNHOaIjETZZuziZdlwPsU5EjBVj5M0dUbwrSQTTNZe0SxX3pQ1QFVcs5KyvdS7AQcpBVdLjx4CfQjdKXk52GA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-6.9.0.tgz",
+      "integrity": "sha512-SxTSOetEKD+WPzvDuYRsP1+KkwUp8KqL1n7oFx9ThxjyfEY0ly0i9KdbvX5yYVDOA2TSwrltgdu14y/Pf6y3Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/promises": "6.9.0",
+        "@solana/transaction-messages": "6.9.0",
+        "@solana/transactions": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instructions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.9.0.tgz",
+      "integrity": "sha512-LZfJx3bGdUSbGaswoOEPHygticqkCg3TusRczPJXyCmKhoQzPCcGQQ99qMzP7Wg8pEV5tWA5t7tycf8E237ydg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/keys": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.9.0.tgz",
+      "integrity": "sha512-1g2QARiqSjNqT0EIqLDLQ5vRm7hCsbqgFwFAp5GsMV/8BTYT8s1Ct2wLHDZiJ4eAX6beTHVf8LbOBfVejtn3oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/promises": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-6.9.0.tgz",
+      "integrity": "sha512-k7BRz7Akfv8wiRtlCR/xUyDLfuMfYMelMR1+AC5KgwaRRJReDF0BucMLNN1In7WoI+KuWwr1OKv4na/oKpyeAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.9.0",
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instruction-plans": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/offchain-messages": "6.9.0",
+        "@solana/plugin-core": "6.9.0",
+        "@solana/plugin-interfaces": "6.9.0",
+        "@solana/program-client-core": "6.9.0",
+        "@solana/programs": "6.9.0",
+        "@solana/rpc": "6.9.0",
+        "@solana/rpc-api": "6.9.0",
+        "@solana/rpc-parsed-types": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0",
+        "@solana/rpc-subscriptions": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/signers": "6.9.0",
+        "@solana/subscribable": "6.9.0",
+        "@solana/sysvars": "6.9.0",
+        "@solana/transaction-confirmation": "6.9.0",
+        "@solana/transaction-messages": "6.9.0",
+        "@solana/transactions": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/nominal-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
+      "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-6.9.0.tgz",
+      "integrity": "sha512-qK3tqRPb+E0kmTz5qFXZbEdF4pyzfOWRZjyVESHVGemDDeGzZ1SV3zAxcA6HBCnv4wCBnlyaDPw8t+5sryNMAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-6.9.0.tgz",
+      "integrity": "sha512-H5ZRWNzzLMwHU/fRU9aVx+3TaMN4gDNCUYxsZxq0h7mqiwxFy6mpy95xPsfdldthCHDYtYnUTxe2sBatGbNHig==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-6.9.0.tgz",
+      "integrity": "sha512-KslLSnzY8zbGZibEBVMVUm2ZS8T2xf+cut7F65VjWPoWNAxU+p7933wsMz/az6CF7b65RI7iU3HhCr5/5QF50w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-interfaces/-/plugin-interfaces-6.9.0.tgz",
+      "integrity": "sha512-Qj4sk9thkM1UgnFXvWIoezd/CbqpX/2jigLBDsMB5Ed/gmFlkBSTL127LFDSY3OtzBpXl4hROs+Zqv+5xqtguA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/instruction-plans": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/rpc-spec": "6.9.0",
+        "@solana/rpc-subscriptions-spec": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/signers": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/program-client-core/-/program-client-core-6.9.0.tgz",
+      "integrity": "sha512-+iUnsddhs72QoBJoUO+/yHUXoBvYWa1sGCBRJk35zeg8j7ZXEwRkk6eX0VOrUPxhEpQbYJsIOCrIYApNIt8RFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.9.0",
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/instruction-plans": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/plugin-interfaces": "6.9.0",
+        "@solana/rpc-api": "6.9.0",
+        "@solana/signers": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-6.9.0.tgz",
+      "integrity": "sha512-L9LAnQtfFFcCDLcbbnxhUtgAmu/kS4aRmrVncdnX5CFyQshlpo0/Qhrq3UA7vnhute4gjYV4pFT+64onH5qGEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/promises": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.9.0.tgz",
+      "integrity": "sha512-227PlXRi6KZX4ODYTkJitr9InSa79NTquI72slay4gzxO9VmMepgvYdMAX6kawdN5pt+VzaklKhNhWXk50Pi9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-6.9.0.tgz",
+      "integrity": "sha512-ny1Kt20+oq3xZErNA56+Magmb2JKYfQgHwZTsBmHKVl/9mBpv1y1+ygV+KNiiX/wWXWstLbdIo1jgPwZPbU2Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/fast-stable-stringify": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/rpc-api": "6.9.0",
+        "@solana/rpc-spec": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0",
+        "@solana/rpc-transformers": "6.9.0",
+        "@solana/rpc-transport-http": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-6.9.0.tgz",
+      "integrity": "sha512-3KhXS6A1ie6GqTywW/KEMSXJ1VJEU66fxjhuiiqPILuJstP7kex3ycr3H6DirKydUsy6gaKaPN43rE+LfyS7OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/rpc-parsed-types": "6.9.0",
+        "@solana/rpc-spec": "6.9.0",
+        "@solana/rpc-transformers": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/transaction-messages": "6.9.0",
+        "@solana/transactions": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-parsed-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-6.9.0.tgz",
+      "integrity": "sha512-6ThH8izY+DWDyrVOOlS40vTcFjwjCinjfqnId7zhRk8OxhkfHQ/iEj+OnGwD4Yhe8pGdVa7GNVYlrQgQgzQ3eQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-6.9.0.tgz",
+      "integrity": "sha512-3yHRoChc0IpsJbUq0/94l+ar3t9U3Ax58W0HON7eyYe7zFP10UAxpkHn7DPch9DeALyuGph8kVnvl+kXRgJlGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-6.9.0.tgz",
+      "integrity": "sha512-A4fY1JRrcKqX3EfttO4Q8L97nGPqdjfekAV0eDyxN5nu9ngf5p7GKenkl7AYDoHLNr6ZX/C96cRADxXjsRJ0iA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-6.9.0.tgz",
+      "integrity": "sha512-IMctZQaMxzvRACQ6ooW98lP+7tVoUJnRgOZtkAdzgBizldQAYPIKd3MulP0jbQPCMfdPsa2Hs0NBcUwfgonq3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/fast-stable-stringify": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/promises": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0",
+        "@solana/rpc-subscriptions-api": "6.9.0",
+        "@solana/rpc-subscriptions-channel-websocket": "6.9.0",
+        "@solana/rpc-subscriptions-spec": "6.9.0",
+        "@solana/rpc-transformers": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/subscribable": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-6.9.0.tgz",
+      "integrity": "sha512-UA/rPQeNx6zQMUFcS8PPPuB4vzUOtSzIY/igMH0DRoP020NyES2GguIb7Zo7sqDNi4n0gkQRhoW4dPVotcNKdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/rpc-subscriptions-spec": "6.9.0",
+        "@solana/rpc-transformers": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/transaction-messages": "6.9.0",
+        "@solana/transactions": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-6.9.0.tgz",
+      "integrity": "sha512-kT8Yne9HjJD2gooaOFNSyKrvaIfOy2GR0Ymv8OfecBCwFStdz+SPo5eYXq8ZWoZbr5E/MMpHgqsHBanqa2Ffyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/rpc-subscriptions-spec": "6.9.0",
+        "@solana/subscribable": "6.9.0",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-6.9.0.tgz",
+      "integrity": "sha512-DbaG67s99vRZQxFMK80UQ7DEKkRJK6JEZeYg/U5UttD6n7ax/vct7qopxGnrt4RCkaaac2fU8Sr+fcnvWQweUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/promises": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0",
+        "@solana/subscribable": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-6.9.0.tgz",
+      "integrity": "sha512-dg4LK2wEBpaY+KRk/SJIkYvrvjdsc1AwD4bkmGY4Fp7EwVlvwBQShAQn78Qi4IP0WQ/0n9ncFyUxgcB1Y01ZuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-6.9.0.tgz",
+      "integrity": "sha512-4gy30fWJcS6jrcXCoP/optFpGJ/gD9xdkE8wDbe1Ys/Y+e4XjyBt45xtTnbdmMdukvdRX+oXS3zgUIYoagpNzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/rpc-spec": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0",
+        "undici-types": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.9.0.tgz",
+      "integrity": "sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/fixed-points": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-6.9.0.tgz",
+      "integrity": "sha512-x7WyoRm9IORMqeSqNivZgyY+RERPkmqWxpINPD13kUH+oaZzonORIgxk2Lz+u5iPRXiJPkdRPrQ4FoFWv8i6kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/offchain-messages": "6.9.0",
+        "@solana/transaction-messages": "6.9.0",
+        "@solana/transactions": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/subscribable": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-6.9.0.tgz",
+      "integrity": "sha512-YV0/BrJNfepf10CTfLwD7kRY1kkELDHd+BbHJZhBeiuiXTY3xQTvvx1RFs3NtfFCcTHG25Uh8NpRacQJnxSSIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-6.9.0.tgz",
+      "integrity": "sha512-e0e+QKr/th9t/O2N1oUoJmcodLghzAtWKUlGb1zyYub0/WJrPImnKqJqp/gDP4tK98mJxopPMcprCeHk4B+TQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-6.9.0.tgz",
+      "integrity": "sha512-fzYCOih7hhtBzzNSkAnxMjeFeQ8U7e27k9i0RsgQc3/e3OCynF5HoIVNhhqZbwfIBKiaD4ginJR6slRnfqO32Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/promises": "6.9.0",
+        "@solana/rpc": "6.9.0",
+        "@solana/rpc-subscriptions": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/transaction-messages": "6.9.0",
+        "@solana/transactions": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.9.0.tgz",
+      "integrity": "sha512-OWpryt0w6SHlwHx12Vd1wvx2QwSGBXAIUEHTCtkctcM3AaZRy5cIl7CAq9iD5PgahUsaOyRLBV0zlCJcC2JrJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.9.0.tgz",
+      "integrity": "sha512-uKPzLwHbjwChfVl82he17ntkh02PfgnMMhN7uOAC+VbkIt1O+EEw8sX87gi6kdG/EV+QBDQXm9PLAo5W0tYylw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/transaction-messages": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
+      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.21.0"
+      }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
+      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.2.0.tgz",
+      "integrity": "sha512-uciYZ5yCmf+QJb18kJw10HjquzM7K0z992vWcI+84KeBpTfXT4hfgfGJ5DQbf/mCBPACofkrjvqgcjZfuujjFA==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/solana/jupiter-bot/package-lock.json
+++ b/solana/jupiter-bot/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "qn-jupiter-trading-bot-test",
+  "name": "solana-jupiter-bot",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "qn-jupiter-trading-bot-test",
+      "name": "solana-jupiter-bot",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/solana/jupiter-bot/package.json
+++ b/solana/jupiter-bot/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "qn-jupiter-trading-bot-test",
+  "name": "solana-jupiter-bot",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "npx tsx --env-file=.env index.ts"
   },
   "keywords": [],
   "author": "",

--- a/solana/jupiter-bot/package.json
+++ b/solana/jupiter-bot/package.json
@@ -1,22 +1,22 @@
 {
-    "name": "solana-jupiter-bot",
-    "version": "1.0.0",
-    "description": "Example trading bot for Solana using Quicknode and Metis API",
-    "scripts": {
-      "start": "ts-node index.ts"
-    },
-    "dependencies": {
-      "@jup-ag/api": "^6.0.0",
-      "@solana/spl-token": "^0.4.13",
-      "@solana/web3.js": "^1.98.0",
-      "dotenv": "^16.3.1"
-    },
-    "devDependencies": {
-      "@types/node": "^22.13.14",
-      "ts-node": "^10.9.1",
-      "typescript": "^5.2.2"
-    },
-    "engines": {
-      "node": ">=16.0.0"
-    }
+  "name": "qn-jupiter-trading-bot-test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@jup-ag/api": "^6.0.48",
+    "@solana-program/address-lookup-table": "^0.11.0",
+    "@solana-program/token": "^0.13.0",
+    "@solana/kit": "^6.9.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.7.0"
   }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it rewrites transaction construction/signing/sending and address lookup table handling using new Solana client libraries, which can change runtime behavior and swap execution reliability.
> 
> **Overview**
> Updates the Jupiter trading bot to use `@solana/kit` and Solana program clients instead of `@solana/web3.js`/`@solana/spl-token`, including new instruction conversion, address lookup table fetching, and a new transaction build/sign/send flow with explicit priority fee settings.
> 
> Refreshes the sample app packaging and developer experience: adds `.gitignore`, introduces `package-lock.json`, switches `start` to `tsx` with `--env-file`, updates default strategy parameters in `index.ts`, and cleans up `.env.example`/`README.md` to match the new endpoints and setup guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8e2a5352112b9dc20c659268d132c2a290cccbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->