### PR TITLE
[CON-795] Fix HIP-4 api/5-trade.ts: gate sell orders, fix openOrders response

### DIFF
--- a/hyperliquid/hip4-prediction-markets/src/api/5-trade.ts
+++ b/hyperliquid/hip4-prediction-markets/src/api/5-trade.ts
@@ -2,9 +2,9 @@
  * API Script 5: Place HIP-4 Trades
  * Demonstrates all order types via hyperliquidapi.com build-sign-send:
  *   - Limit BUY  (GTC)
- *   - Limit SELL (GTC)
+ *   - Limit SELL (GTC)  — requires existing spot balance; set SKIP_SELL_ORDERS=true to skip
  *   - Market BUY  (tif: "market", no price — API auto-computes mid + 3% slippage)
- *   - Market SELL (tif: "market", no price)
+ *   - Market SELL (tif: "market", no price) — same requirement as limit sell
  *   - Cancel resting orders
  *
  * HIP-4 rules:
@@ -12,7 +12,9 @@
  *   - grouping: "na"  (no priorityFee support)
  *   - Minimum order value: 10 USDC (size * price >= 10)
  *
- * Set SKIP_MARKET_ORDERS=true to skip market order examples.
+ * Env flags:
+ *   SKIP_MARKET_ORDERS=true  — skip market buy/sell examples
+ *   SKIP_SELL_ORDERS=true    — skip all sell examples (use if wallet has no token balance)
  */
 import { buildSignSend, hlInfo, apiGet, getAccount } from "./client.js";
 
@@ -98,27 +100,35 @@ const limitBuyOid: number | null =
 console.log("OID:", limitBuyOid);
 
 // ── LIMIT SELL (GTC) ──────────────────────────────────────────
-console.log("\n── Limit SELL (GTC) ─────────────────────────────────────");
-console.log(`Placing: SELL ${limitSize} ${yesSymbol} @ ${sellPrice}`);
+// Requires existing spot balance of the YES token. Set SKIP_SELL_ORDERS=true to skip.
+const skipSell = process.env.SKIP_SELL_ORDERS === "true";
+let limitSellOid: number | null = null;
 
-const limitSellResult = await buildSignSend({
-  type: "order",
-  orders: [{
-    asset: yesSymbol,
-    side: "sell",
-    price: String(sellPrice),
-    size: limitSize,
-    tif: "gtc",
-  }],
-}) as any;
+if (skipSell) {
+  console.log("\n── Limit SELL (skipped — SKIP_SELL_ORDERS=true) ─────────");
+} else {
+  console.log("\n── Limit SELL (GTC) ─────────────────────────────────────");
+  console.log(`Placing: SELL ${limitSize} ${yesSymbol} @ ${sellPrice}`);
 
-console.log(JSON.stringify(limitSellResult, null, 2));
+  const limitSellResult = await buildSignSend({
+    type: "order",
+    orders: [{
+      asset: yesSymbol,
+      side: "sell",
+      price: String(sellPrice),
+      size: limitSize,
+      tif: "gtc",
+    }],
+  }) as any;
 
-const limitSellOid: number | null =
-  limitSellResult?.exchangeResponse?.data?.statuses?.[0]?.resting?.oid ??
-  limitSellResult?.exchangeResponse?.data?.statuses?.[0]?.filled?.oid ??
-  null;
-console.log("OID:", limitSellOid);
+  console.log(JSON.stringify(limitSellResult, null, 2));
+
+  limitSellOid =
+    limitSellResult?.exchangeResponse?.data?.statuses?.[0]?.resting?.oid ??
+    limitSellResult?.exchangeResponse?.data?.statuses?.[0]?.filled?.oid ??
+    null;
+  console.log("OID:", limitSellOid);
+}
 
 // ── ORDER STATUS ──────────────────────────────────────────────
 if (limitBuyOid) {
@@ -132,14 +142,15 @@ if (limitBuyOid) {
 }
 
 // ── OPEN ORDERS ───────────────────────────────────────────────
-const openOrders = await fetch("https://send.hyperliquidapi.com/openOrders", {
+const openOrdersRaw = await fetch("https://send.hyperliquidapi.com/openOrders", {
   method: "POST",
   headers: { "Content-Type": "application/json" },
   body: JSON.stringify({ user: walletAddress }),
-}).then(r => r.json()) as any[];
+}).then(r => r.json()) as any;
+const openOrders: any[] = Array.isArray(openOrdersRaw) ? openOrdersRaw : (openOrdersRaw?.orders ?? []);
 
-console.log(`\n── Open Orders (${openOrders?.length ?? 0}) ─────────────────────────────────`);
-for (const o of openOrders ?? []) {
+console.log(`\n── Open Orders (${openOrders.length}) ─────────────────────────────────`);
+for (const o of openOrders) {
   console.log(`  oid=${o.oid}  coin=${o.coin}  side=${o.side}  px=${o.limitPx}  sz=${o.sz}`);
 }
 
@@ -166,19 +177,23 @@ if (skipMarket) {
   }) as any;
   console.log(JSON.stringify(mktBuyResult, null, 2));
 
-  console.log("\n── Market SELL (IOC, auto-slippage) ─────────────────────");
-  console.log(`Placing: marketSell ${marketSize} ${yesSymbol}`);
+  if (skipSell) {
+    console.log("\n── Market SELL (skipped — SKIP_SELL_ORDERS=true) ────────");
+  } else {
+    console.log("\n── Market SELL (IOC, auto-slippage) ─────────────────────");
+    console.log(`Placing: marketSell ${marketSize} ${yesSymbol}`);
 
-  const mktSellResult = await buildSignSend({
-    type: "order",
-    orders: [{
-      asset: yesSymbol,
-      side: "sell",
-      size: marketSize,
-      tif: "market",
-    }],
-  }) as any;
-  console.log(JSON.stringify(mktSellResult, null, 2));
+    const mktSellResult = await buildSignSend({
+      type: "order",
+      orders: [{
+        asset: yesSymbol,
+        side: "sell",
+        size: marketSize,
+        tif: "market",
+      }],
+    }) as any;
+    console.log(JSON.stringify(mktSellResult, null, 2));
+  }
 }
 
 // ── CANCEL resting limit orders ───────────────────────────────


### PR DESCRIPTION
## Summary

- Add `SKIP_SELL_ORDERS=true` env flag to gate limit and market sell examples — sell orders require an existing spot token balance; new wallets start with none, causing a misleading error
- Fix `openOrders` `TypeError: not iterable` — normalize the `/openOrders` response with `Array.isArray` check before iterating, handling both plain-array and wrapped-object response shapes

## Related

Companion docs PR: _to be linked_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example/documentation script only; no production trading or auth paths changed.
> 
> **Overview**
> Updates the HIP-4 **API demo script** `api/5-trade.ts` so it runs cleanly on wallets without YES spot balance and when `/openOrders` returns a wrapped payload.
> 
> Adds **`SKIP_SELL_ORDERS=true`** (documented alongside `SKIP_MARKET_ORDERS`) to skip limit and market **sell** examples that need an existing token balance; sell OIDs stay `null` when skipped so cancel logic still works for buy-only runs.
> 
> Fixes **`TypeError: not iterable`** by normalizing the `/openOrders` JSON to an array via `Array.isArray(openOrdersRaw) ? openOrdersRaw : (openOrdersRaw?.orders ?? [])` before logging and iterating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2715ea69e736f517f0b6c2f90c5876b9df095c63. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->