### PR TITLE
[CON-794] Migrate audit-token-activity from @quicknode/sdk to viem

### DIFF
--- a/ethereum/audit-token-activity/README.md
+++ b/ethereum/audit-token-activity/README.md
@@ -1,11 +1,11 @@
-# Audit ERC20, ERC721, and ERC1155 Token Activity using Quicknode SDK
+# Audit ERC20, ERC721, and ERC1155 Token Activity
 
-This project is based on the guide, [How to Audit ERC20, ERC721, and ERC1155 Token Activity using Quicknode SDK](https://www.quicknode.com/guides/ethereum-development/transactions/how-to-audit-token-activity-using-quicknode-sdk) by Sergen Uysal. Using JavaScript and the Quicknode SDK, this tool fetches and analyzes transactions across ERC20, ERC721, and ERC1155 token standards to conducting comprehensive audits on blockchain wallets, specifically tailored for EVM-compatible chains.
+This project is based on the guide, [How to Audit ERC20, ERC721, and ERC1155 Token Activity](https://www.quicknode.com/guides/ethereum-development/transactions/how-to-audit-token-activity) by Sergen Uysal. Using JavaScript and Viem, this tool fetches and analyzes transactions across ERC20, ERC721, and ERC1155 token standards to conduct comprehensive audits on blockchain wallets, specifically tailored for EVM-compatible chains.
 
 ### Prerequisites
 
 - A [Quicknode account](https://www.quicknode.com/?utm_source=qn-github&utm_campaign=explorer&utm_content=sign-up&utm_medium=generic).
-- [Node.JS](https://nodejs.org/en/) installed.
+- [Node.JS](https://nodejs.org/en/) v20 or higher installed.
 
 ## Clone Example Monorepo
 
@@ -23,11 +23,11 @@ npm install
 
 1. Obtain a Quicknode endpoint URL for the EVM chain that you want.
 2. Open the `index.js` file.
-3. Locate the `Core` object instantiation. It should look like this:
+3. Locate the `createPublicClient` call. It should look like this:
 
 ```javascript
-const core = new Core({
-  endpointUrl: "QUICKNODE_ENDPOINT",
+const client = createPublicClient({
+  transport: http("QUICKNODE_ENDPOINT"),
 });
 ```
 4. Replace `QUICKNODE_ENDPOINT` with your actual Quicknode endpoint URL.
@@ -43,10 +43,10 @@ At the end of the `index.js` file, you will find the `run` function call. This f
 
 ### Example Usage
 
-The file contains a pre-configured example that audits a specific address for both ERC20 and ERC721 token transfers:
+The file contains a pre-configured example that audits a specific address for ERC20, ERC721, and ERC1155 token transfers:
 
 ```javascript
-run(['0xe2233D97f30745fa5f15761B81B281BE5959dB5C'], 38063215, 38063220, ['ERC20', 'ERC721']);
+run(['0xe2233D97f30745fa5f15761B81B281BE5959dB5C'], 38063215, 38063220, ['ERC20', 'ERC721', 'ERC1155']);
 ```
 
 Feel free to modify this example with your desired parameters.
@@ -67,4 +67,4 @@ Upon successful execution, the script will generate a `wallet_audit_data.json` f
 
 ## Support
 
-For additional assistance or queries regarding the setup and usage, feel free to reach out to us by using the feedback form in the [Conclusion section of the guide](https://www.quicknode.com/guides/ethereum-development/transactions/how-to-audit-token-activity-using-quicknode-sdk#conclusion).
+For additional assistance or queries regarding the setup and usage, feel free to reach out to us by using the feedback form in the [Conclusion section of the guide](https://www.quicknode.com/guides/ethereum-development/transactions/how-to-audit-token-activity#conclusion).

--- a/ethereum/audit-token-activity/index.js
+++ b/ethereum/audit-token-activity/index.js
@@ -1,24 +1,25 @@
 // Importing necessary modules and libraries
-import { Core, viem } from "@quicknode/sdk"; // Importing Core and viem from the Quicknode SDK
+import { createPublicClient, http } from "viem"; // Importing Viem client utilities
+import * as viem from "viem"; // Importing Viem helpers
 import fs from "fs-extra"; // Importing the file system module for file operations
 import * as cli from "cli-progress"; // Importing the CLI progress bar module for visual progress feedback in the console
 
-// Creating a new instance of Core from the Quicknode SDK
-const core = new Core({
-  endpointUrl: "QUICKNODE_ENDPOINT", // The endpoint URL of your Quicknode. Replace "QUICKNODE_ENDPOINT" with your actual Quicknode endpoint URL.
+// Creating a Viem public client using your Quicknode endpoint
+const client = createPublicClient({
+  transport: http("QUICKNODE_ENDPOINT"), // The endpoint URL of your Quicknode. Replace "QUICKNODE_ENDPOINT" with your actual Quicknode endpoint URL.
 });
 
 // Function to get ERC20 token transfers for a specific address within a given block
 async function getERC20TokenTransfers(address, blockNum) {
   const transfers = []; // Array to store the transfers
 
-  // Convert the block number to hexadecimal format
-  const blockHex = viem.toHex(blockNum);
+  // Convert the block number to bigint format for Viem
+  const blockNumber = BigInt(blockNum);
 
   // Fetch logs of token transfers sent from the given address
-  const sentTransfers = await core.client.getLogs({
-    fromBlock: blockHex,
-    toBlock: blockHex,
+  const sentTransfers = await client.getLogs({
+    fromBlock: blockNumber,
+    toBlock: blockNumber,
     event: viem.parseAbiItem(
       "event Transfer(address indexed from, address indexed to, uint256 value)"
     ),
@@ -33,9 +34,9 @@ async function getERC20TokenTransfers(address, blockNum) {
   transfers.push(...parsedEvents);
 
   // Fetch logs of token transfers received by the given address
-  const receivedTransfers = await core.client.getLogs({
-    fromBlock: blockHex,
-    toBlock: blockHex,
+  const receivedTransfers = await client.getLogs({
+    fromBlock: blockNumber,
+    toBlock: blockNumber,
     event: viem.parseAbiItem(
       "event Transfer(address indexed from, address indexed to, uint256 value)"
     ),
@@ -55,13 +56,13 @@ async function getERC20TokenTransfers(address, blockNum) {
 async function getERC721TokenTransfers(address, blockNum) {
   const transfers = []; // Array to store the transfers
 
-  // Convert the block number to hexadecimal format
-  const blockHex = viem.toHex(blockNum);
+  // Convert the block number to bigint format for Viem
+  const blockNumber = BigInt(blockNum);
 
   // Fetch logs of ERC721 token transfers sent from the given address
-  const sentTransfers = await core.client.getLogs({
-    fromBlock: blockHex,
-    toBlock: blockHex,
+  const sentTransfers = await client.getLogs({
+    fromBlock: blockNumber,
+    toBlock: blockNumber,
     event: viem.parseAbiItem(
       "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)"
     ),
@@ -76,9 +77,9 @@ async function getERC721TokenTransfers(address, blockNum) {
   transfers.push(...parsedEvents);
 
   // Fetch logs of ERC721 token transfers received by the given address
-  const receivedTransfers = await core.client.getLogs({
-    fromBlock: blockHex,
-    toBlock: blockHex,
+  const receivedTransfers = await client.getLogs({
+    fromBlock: blockNumber,
+    toBlock: blockNumber,
     event: viem.parseAbiItem(
       "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)"
     ),
@@ -99,13 +100,13 @@ async function getERC721TokenTransfers(address, blockNum) {
 async function getERC1155TokenTransfers(address, blockNum) {
   const transfers = []; // Array to store the transfers
 
-  // Convert the block number to hexadecimal format
-  const blockHex = viem.toHex(blockNum);
+  // Convert the block number to bigint format for Viem
+  const blockNumber = BigInt(blockNum);
 
   // Fetch logs of ERC1155 token transfers sent from the given address (for single transfers)
-  let sentTransfers = await core.client.getLogs({
-    fromBlock: blockHex,
-    toBlock: blockHex,
+  let sentTransfers = await client.getLogs({
+    fromBlock: blockNumber,
+    toBlock: blockNumber,
     event: viem.parseAbiItem(
       "event TransferSingle(address indexed _operator, address indexed _from, address indexed _to, uint256 _id, uint256 _value)"
     ),
@@ -118,9 +119,9 @@ async function getERC1155TokenTransfers(address, blockNum) {
   transfers.push(...parsedEvents);
 
   // Fetch logs of ERC1155 token transfers sent from the given address (for batch transfers)
-  sentTransfers = await core.client.getLogs({
-    fromBlock: blockHex,
-    toBlock: blockHex,
+  sentTransfers = await client.getLogs({
+    fromBlock: blockNumber,
+    toBlock: blockNumber,
     event: viem.parseAbiItem(
       "event TransferBatch(address indexed _operator, address indexed _from, address indexed _to, uint256[] _ids, uint256[] _values)"
     ),
@@ -133,9 +134,9 @@ async function getERC1155TokenTransfers(address, blockNum) {
   transfers.push(...parsedEvents);
 
   // Fetch logs of ERC1155 token transfers received by the given address (for single transfers)
-  let receivedTransfers = await core.client.getLogs({
-    fromBlock: blockHex,
-    toBlock: blockHex,
+  let receivedTransfers = await client.getLogs({
+    fromBlock: blockNumber,
+    toBlock: blockNumber,
     event: viem.parseAbiItem(
       "event TransferSingle(address indexed _operator, address indexed _from, address indexed _to, uint256 _id, uint256 _value)"
     ),
@@ -148,9 +149,9 @@ async function getERC1155TokenTransfers(address, blockNum) {
   transfers.push(...parsedEvents);
 
   // Fetch logs of ERC1155 token transfers received by the given address (for batch transfers)
-  receivedTransfers = await core.client.getLogs({
-    fromBlock: blockHex,
-    toBlock: blockHex,
+  receivedTransfers = await client.getLogs({
+    fromBlock: blockNumber,
+    toBlock: blockNumber,
     event: viem.parseAbiItem(
       "event TransferBatch(address indexed _operator, address indexed _from, address indexed _to, uint256[] _ids, uint256[] _values)"
     ),
@@ -187,7 +188,7 @@ function parseTransferEvents(events) {
 async function getInternalTransactions(txHash) {
   try {
     // Requesting a trace of the transaction using the debug_traceTransaction method
-    const traceResponse = await core.client.request({
+    const traceResponse = await client.request({
       method: "debug_traceTransaction",
       params: [txHash, { tracer: "callTracer" }], // Using a call tracer for detailed transaction execution
     });
@@ -232,8 +233,8 @@ async function getTransactionsForAddresses(
     blockNum === toBlock ? bar1.stop() : bar1.increment();
 
     // Fetch the block and its transactions
-    const block = await core.client.getBlock({
-      blockNumber: blockNum,
+    const block = await client.getBlock({
+      blockNumber: BigInt(blockNum),
       includeTransactions: true,
     });
 
@@ -316,14 +317,16 @@ async function getTransactionsForAddresses(
         }
 
         // Fetch and add internal transactions if applicable
-        const bytecode = await core.client.getBytecode({
-          address: tx.to,
-        });
+        if (tx.to) {
+          const bytecode = await client.getBytecode({
+            address: tx.to,
+          });
 
-        if (tx.to && bytecode !== "0x") {
-          txDetails.internalTransactions.push(
-            ...(await getInternalTransactions(tx.hash))
-          );
+          if (bytecode && bytecode !== "0x") {
+            txDetails.internalTransactions.push(
+              ...(await getInternalTransactions(tx.hash))
+            );
+          }
         }
         // Add the detailed transaction to the transactions array
         transactions.push(txDetails);

--- a/ethereum/audit-token-activity/package.json
+++ b/ethereum/audit-token-activity/package.json
@@ -11,7 +11,7 @@
   "author": "Sergen Uysal",
   "license": "ISC",
   "dependencies": {
-    "@quicknode/sdk": "^1.1.4",
+    "viem": "^2.0.0",
     "cli-progress": "^3.12.0",
     "fs-extra": "^11.1.1"
   }


### PR DESCRIPTION
## Summary
- Replace `@quicknode/sdk` Core client with direct `viem` `createPublicClient`/`http`
- Update block number handling from hex (`toHex`) to `BigInt`
- Update `package.json` dependency from `@quicknode/sdk` to `viem ^2.0.0`
- Update README title, guide link, and instructions to remove SDK references

## Test plan
- [ ] Run `npm install` and confirm `viem` installs without errors
- [ ] Replace `QUICKNODE_ENDPOINT` and run `node index.js` to confirm `wallet_audit_data.json` is generated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example/guide-only RPC refactor with no auth or production service changes; behavior should match aside from the stricter internal-tx bytecode check.
> 
> **Overview**
> Replaces the Quicknode **Core** wrapper with a direct **Viem** `createPublicClient` + `http` transport while keeping the same Quicknode endpoint URL. All RPC usage (`getLogs`, `getBlock`, `getBytecode`, `debug_traceTransaction`) now goes through that client instead of `core.client`.
> 
> Block-scoped calls switch from hex block tags (`viem.toHex`) to **`BigInt` block numbers**, including `getBlock`. Internal-tx tracing only runs when `tx.to` is set **and** bytecode is non-empty (guards against missing bytecode).
> 
> **`package.json`** drops `@quicknode/sdk` and adds **`viem ^2.0.0`**. The **README** and sample **`run(...)`** call are updated for Viem setup, the new guide URL, Node v20+, and ERC1155 in the example token list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5942502fc9802e33540dd7321da84815fc8cef9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->